### PR TITLE
Promisify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## 4.0.0 - 2022-01-25
+- Refactor internals to use classes & ES6 syntax
+- Drop support for nodejs < 16
+- Update `prompt` module to use promises internally
+
 ## 3.2.1 - 2022-01-10
-- Pins `colors` dependency to version 1.4.0. 
+- Pins `colors` dependency to version 1.4.0.
 
 ## 3.2.0 - 2021-04-05
 - Adds an `--expand` flag to enable `CAPABILITY_AUTO_EXPAND` on changeset generation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:16-alpine
-
-COPY . ./
-
-RUN npm install
-
-CMD npm test

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ npm install --save @mapbox/cfn-config
 Then, in your scripts:
 
 ```js
-var cfnConfig = require('@mapbox/cfn-config');
+const cfnConfig = require('@mapbox/cfn-config');
 ```
 
 ## JavaScript Usage
@@ -96,49 +96,59 @@ High-level prompting routines to create, update, and delete stacks are provided,
 First, create a commands object:
 
 ```js
-var options = {
-  name: 'my-stack', // the base name of the stack
-  region: 'us-east-1', // the region where the stack resides
-  templatePath: '~/my-stack/cfn.template.json', // the template file
-  configBucket: 'my-cfn-configurations', // bucket for configuration files
-  templateBucket: 'cfn-config-templates-123456789012-us-east-1' // bucket for templates
+const options = {
+    name: 'my-stack', // the base name of the stack
+    region: 'us-east-1', // the region where the stack resides
+    templatePath: '~/my-stack/cfn.template.json', // the template file
+    configBucket: 'my-cfn-configurations', // bucket for configuration files
+    templateBucket: 'cfn-config-templates-123456789012-us-east-1' // bucket for templates
 };
 
-var commands = cfnConfig.commands(options);
+const commands = cfnConfig.commands(options);
 ```
 
 Then, perform the desired operation:
 
 ```js
 // Create a stack called `my-stack-testing`
-commands.create('testing', '~/my-stack/cfn.template.json', function(err) {
-  if (err) console.error(`Create failed: ${err.message}`);
-  else console.log('Create succeeded');
-});
+try {
+    await commands.create('testing', '~/my-stack/cfn.template.json');
+    console.log('Create succeeded');
+} catch (err) {
+    console.error(`Create failed: ${err.message}`);
+}
 
 // Update the stack with a different version of the template
-commands.update('testing', '~/my-stack/cfn.template-v2.json', function(err) {
-  if (err) console.error(`Update failed: ${err.message}`);
-  else console.log('Update succeeded');
-});
+try {
+    await commands.update('testing', '~/my-stack/cfn.template-v2.json');
+    console.log('Update succeeded');
+} catch (err) {
+    console.error(`Update failed: ${err.message}`);
+}
 
 // Save the stack's configuration to S3
-commands.save('testing', function(err) {
-  if (err) console.error(`Failed to save configuration: ${err.message}`);
-  else console.log('Saved configuration');
-});
+try {
+    await commands.save('testing');
+    console.log('Saved configuration');
+} catch (err) {
+    console.error(`Failed to save configuration: ${err.message}`);
+}
 
 // Get information about the stack
-commands.info('testing', function(err, info) {
-  if (err) console.error(`Failed to read stack info: ${err.message}`);
-  else console.log(JSON.stringify(info, null, 2));
-});
+try {
+    await commands.info('testing');
+    console.log(JSON.stringify(info, null, 2));
+} catch (err) {
+    console.error(`Failed to read stack info: ${err.message}`);
+}
 
 // Delete the stack
-commands.delete('testing', function(err) {
-  if (err) console.error(`Delete failed: ${err.message}`);
-  else console.log('Delete succeeded');
-});
+try {
+    await commands.delete('testing');
+    console.log('Delete succeeded');
+} catch (err) {
+    console.error(`Delete failed: ${err.message}`);
+}
 ```
 
 For low-level functions, see documentation in the code for now. More legible docs are to come.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const options = {
     templateBucket: 'cfn-config-templates-123456789012-us-east-1' // bucket for templates
 };
 
-const commands = cfnConfig.commands(options);
+const commands = new cfnConfig.Commands(options);
 ```
 
 Then, perform the desired operation:

--- a/index.js
+++ b/index.js
@@ -4,9 +4,15 @@ module.exports.Actions = require('./lib/actions'),
 module.exports.Commands = require('./lib/commands').Commands,
 module.exports.Lookup = require('./lib/lookup'),
 module.exports.Prompt = require('./lib/prompt'),
-module.exports.Template = require('./lib/template')
+module.exports.Template = require('./lib/template');
 
 module.exports.preauth = (credentials) => {
     AWS.config.credentials = credentials;
-    return cfnConfig;
+    return {
+        Actions: require('./lib/actions'),
+        Commands: require('./lib/commands').Commands,
+        Lookup: require('./lib/lookup'),
+        Prompt: require('./lib/prompt'),
+        Template: require('./lib/template')
+    };
 };

--- a/index.js
+++ b/index.js
@@ -1,14 +1,10 @@
 const AWS = require('aws-sdk');
 
-const cfnConfig = {
-    Actions: require('./lib/actions'),
-    Commands: require('./lib/commands').Commands,
-    Lookup: require('./lib/lookup'),
-    Prompt: require('./lib/prompt'),
-    Template: require('./lib/template')
-};
-
-module.exports = cfnConfig;
+module.exports.Actions = require('./lib/actions'),
+module.exports.Commands = require('./lib/commands').Commands,
+module.exports.Lookup = require('./lib/lookup'),
+module.exports.Prompt = require('./lib/prompt'),
+module.exports.Template = require('./lib/template')
 
 module.exports.preauth = (credentials) => {
     AWS.config.credentials = credentials;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const AWS = require('aws-sdk');
 
 const cfnConfig = {
-    actions: require('./lib/actions'),
-    commands: require('./lib/commands'),
-    lookup: require('./lib/lookup'),
-    prompt: require('./lib/prompt'),
-    template: require('./lib/template')
+    Actions: require('./lib/actions'),
+    Commands: require('./lib/commands'),
+    Lookup: require('./lib/lookup'),
+    Prompt: require('./lib/prompt'),
+    Template: require('./lib/template')
 };
 
 module.exports = cfnConfig;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const AWS = require('aws-sdk');
 
 const cfnConfig = {
     Actions: require('./lib/actions'),
-    Commands: require('./lib/commands'),
+    Commands: require('./lib/commands').Commands,
     Lookup: require('./lib/lookup'),
     Prompt: require('./lib/prompt'),
     Template: require('./lib/template')

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -331,21 +331,22 @@ async function describeChangeset(cfn, name, changesetId) {
     let changesetDescriptions;
     let changes = [];
 
-    let nextToken = undefined;
+    let nextToken = true;
     do {
         const data = await cfn.describeChangeSet({
             ChangeSetName: changesetId,
             StackName: name,
-            NextToken: nextToken
+            NextToken: nextToken === true ? undefined : nextToken
         }).promise();
 
         changesetDescriptions = data;
 
         if (data.Status === 'CREATE_COMPLETE' || data.Status === 'FAILED' || data.status === 'DELETE_COMPLETE') {
             changes = changes.concat(data.Changes || []);
+            if (!data.NextToken) break;
         }
 
-        nextToken = data.NextToken;
+        nextToken = data.NextToken || true;
         if (nextToken) await sleep(1000);
     } while (nextToken);
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -343,16 +343,14 @@ async function describeChangeset(cfn, name, changesetId) {
 
         if (data.Status === 'CREATE_COMPLETE' || data.Status === 'FAILED' || data.status === 'DELETE_COMPLETE') {
             changes = changes.concat(data.Changes || []);
-
-            if (!data.NextToken) {
-                if (changes.length) changesetDescriptions.Changes = changes;
-                return changesetDescriptions;
-            }
         }
-        nextToken = data.NextToken;
 
-        await sleep(1000);
+        nextToken = data.NextToken;
+        if (nextToken) await sleep(1000);
     } while (nextToken);
+
+    if (changes.length) changesetDescriptions.Changes = changes;
+    return changesetDescriptions;
 }
 
 function sleep(ms) {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -6,7 +6,7 @@ const cuid = require('cuid');
 const error = require('fasterror');
 const s3urls = require('s3urls');
 const eventStream = require('cfn-stack-event-stream');
-const lookup = require('./lookup');
+const Lookup = require('./lookup');
 
 require('colors');
 
@@ -44,10 +44,8 @@ class Actions {
      * @param {string} changeSetType - the type of changeset, either UPDATE or CREATE
      * @param {string} templateUrl - the URL for the template on S3
      * @param {object} parameters - parameters for the ChangeSet
-     * @param {function} callback - a function provided with a summary of the changes that
-     * this change will perform to stack resources
      */
-    static diff(name, region, changeSetType, templateUrl, parameters, expand, callback) {
+    static async diff(name, region, changeSetType, templateUrl, parameters, expand) {
         const cfn = new AWS.CloudFormation({
             region: region
         });
@@ -55,31 +53,35 @@ class Actions {
         const changeSetParameters = changeSet(name, changeSetType, templateUrl, parameters, expand);
         changeSetParameters.ChangeSetName = changesetId;
 
-        cfn.createChangeSet(changeSetParameters, (err) => {
-            if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
+        try {
+            await cfn.createChangeSet(changeSetParameters).promise();
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
 
-            describeChangeset(cfn, name, changesetId, (err, data) => {
-                if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
+        try {
+            const data = await describeChangeset(cfn, name, changesetId);
 
-                const details = {
-                    id: data.ChangeSetName,
-                    status: data.Status,
-                    execution: data.ExecutionStatus
+            const details = {
+                id: data.ChangeSetName,
+                status: data.Status,
+                execution: data.ExecutionStatus
+            };
+
+            if (data.Changes) details.changes = data.Changes.map((change) => {
+                return {
+                    id: change.ResourceChange.PhysicalResourceId,
+                    name: change.ResourceChange.LogicalResourceId,
+                    type: change.ResourceChange.ResourceType,
+                    action: change.ResourceChange.Action,
+                    replacement: change.ResourceChange.Replacement === 'True'
                 };
-
-                if (data.Changes) details.changes = data.Changes.map((change) => {
-                    return {
-                        id: change.ResourceChange.PhysicalResourceId,
-                        name: change.ResourceChange.LogicalResourceId,
-                        type: change.ResourceChange.ResourceType,
-                        action: change.ResourceChange.Action,
-                        replacement: change.ResourceChange.Replacement === 'True'
-                    };
-                });
-
-                callback(null, details);
             });
-        });
+
+            return details;
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
     }
 
     /**
@@ -88,32 +90,37 @@ class Actions {
      * @param {string} name - the name of the existing stack to update
      * @param {string} region - the region the stack is in
      * @param {string} changesetId - the name or ARN of an existing changeset
-     * @param {function} callback - a function called when the stack update has been invoked
      */
-    static executeChangeSet(name, region, changesetId, callback) {
+    static async executeChangeSet(name, region, changesetId) {
         const cfn = new AWS.CloudFormation({
             region: region
         });
 
-        describeChangeset(cfn, name, changesetId, (err, data) => {
-            if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
+        let data;
+        try {
+            data = await describeChangeset(cfn, name, changesetId);
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
 
-            if (data.ExecutionStatus !== 'AVAILABLE') {
-                err = new Actions.ChangeSetNotExecutableError('Cannot execute changeset');
-                err.execution = data.ExecutionStatus;
-                err.status = data.Status;
-                err.reason = data.StatusReason;
-                return callback(err);
-            }
+        if (data.ExecutionStatus !== 'AVAILABLE') {
+            const err = new Actions.ChangeSetNotExecutableError('Cannot execute changeset');
+            err.execution = data.ExecutionStatus;
+            err.status = data.Status;
+            err.reason = data.StatusReason;
+            throw err;
+        }
 
-            cfn.executeChangeSet({
+        try {
+            await cfn.executeChangeSet({
                 StackName: name,
                 ChangeSetName: changesetId
-            }, (err) => {
-                if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
-                callback();
-            });
-        });
+            }).promise();
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
+
+        return;
     }
 
     /**
@@ -121,19 +128,21 @@ class Actions {
      *
      * @param {string} name - the name of the existing stack to update
      * @param {string} region - the region the stack is in
-     * @param {function} callback - a function called when stack deletion is complete
      */
-    static delete(name, region, callback) {
+    static async delete(name, region) {
         const cfn = new AWS.CloudFormation({
             region: region
         });
 
-        cfn.deleteStack({
-            StackName: name
-        }, (err) => {
-            if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
-            callback();
-        });
+        try {
+            await cfn.deleteStack({
+                StackName: name
+            }).promise();
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
+
+        return;
     }
 
     /**
@@ -141,27 +150,28 @@ class Actions {
      *
      * @param {string} name - the full name of the existing stack to update
      * @param {string} region - the region the stack is in
-     * @param {function} callback - a function called when stack action is complete
      */
-    static monitor(name, region, callback) {
-        const cfn = new AWS.CloudFormation({
-            region: region
-        });
-
-        const events = eventStream(cfn, name)
-            .on('error', (err) => {
-                return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
+    static monitor(name, region) {
+        return new Promise((resolve, reject) => {
+            const cfn = new AWS.CloudFormation({
+                region: region
             });
 
-        const stringify = new stream.Transform({ objectMode: true });
-        stringify._transform = (event, enc, callback) => {
-            let msg = event.ResourceStatus[colors[event.ResourceStatus]] + ' ' + event.LogicalResourceId;
-            if (event.ResourceStatusReason) msg += ': ' + event.ResourceStatusReason;
-            callback(null, currentTime() + ' ' + region + ': ' + msg + '\n');
-        };
+            const events = eventStream(cfn, name)
+                .on('error', (err) => {
+                    return reject(new Actions.CloudFormationError('%s: %s', err.code, err.message));
+                });
 
-        events.pipe(stringify).pipe(process.stdout);
-        stringify.on('end', callback);
+            const stringify = new stream.Transform({ objectMode: true });
+            stringify._transform = (event, enc, cb) => {
+                let msg = event.ResourceStatus[colors[event.ResourceStatus]] + ' ' + event.LogicalResourceId;
+                if (event.ResourceStatusReason) msg += ': ' + event.ResourceStatusReason;
+                cb(null, currentTime() + ' ' + region + ': ' + msg + '\n');
+            };
+
+            events.pipe(stringify).pipe(process.stdout);
+            stringify.on('end', resolve);
+        });
     }
 
     /**
@@ -169,21 +179,21 @@ class Actions {
      *
      * @param {string} region - the region the stack would run in
      * @param {string} templateUrl - the URL for the template on S3
-     * @param {function} callback - a function called when the template has been validated.
-     * An invalid template will result in an error being provided to the callback. No error
-     * object indicates that the template appears valid.
      */
-    static validate(region, templateUrl, callback) {
+    static async validate(region, templateUrl) {
         const cfn = new AWS.CloudFormation({
             region: region
         });
 
-        cfn.validateTemplate({
-            TemplateURL: templateUrl
-        }, (err) => {
-            if (err) return callback(new Actions.CloudFormationError('%s: %s', err.code, err.message));
-            callback();
-        });
+        try {
+            await cfn.validateTemplate({
+                TemplateURL: templateUrl
+            }).promise();
+        } catch (err) {
+            throw new Actions.CloudFormationError('%s: %s', err.code, err.message);
+        }
+
+        return;
     }
 
     /**
@@ -196,40 +206,37 @@ class Actions {
      * @param {object} parameters - name/value pairs defining the stack configuration to save
      * @param {string} [kms] - if desired, the ID of the AWS KMS master encryption key to use
      * to encrypt this configuration at rest
-     * @param {function} callback - a function that will be called when the configuration is saved
      */
-    static saveConfiguration(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
-        if (typeof kms === 'function') {
-            callback = kms;
-            kms = null;
+    static async saveConfiguration(baseName, stackName, stackRegion, bucket, parameters, kms=false) {
+        const region = await Lookup.bucketRegion(bucket, stackRegion);
+
+        const s3 = new AWS.S3({
+            region: region,
+            signatureVersion: 'v4'
+        });
+
+        const params = {
+            Bucket: bucket,
+            Key: Lookup.configKey(baseName, stackName, stackRegion),
+            Body: JSON.stringify(parameters)
+        };
+
+        if (kms) {
+            params.ServerSideEncryption = 'aws:kms';
+            params.SSEKMSKeyId = kms;
         }
 
-        lookup.bucketRegion(bucket, stackRegion, (err, region) => {
-            const s3 = new AWS.S3({
-                region: region,
-                signatureVersion: 'v4'
-            });
-
-            const params = {
-                Bucket: bucket,
-                Key: lookup.configKey(baseName, stackName, stackRegion),
-                Body: JSON.stringify(parameters)
-            };
-
-            if (kms) {
-                params.ServerSideEncryption = 'aws:kms';
-                params.SSEKMSKeyId = kms;
+        try {
+            await s3.putObject(params).promise();
+        } catch (err) {
+            if (err.code === 'NoSuchBucket') {
+                throw new Actions.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region);
+            } else {
+                throw new Actions.S3Error('%s: %s', err.code, err.message);
             }
+        }
 
-            s3.putObject(params, (err) => {
-                if (err && err.code === 'NoSuchBucket')
-                    return callback(new Actions.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region));
-                if (err)
-                    return callback(new Actions.S3Error('%s: %s', err.code, err.message));
-
-                callback();
-            });
-        });
+        return;
     }
 
     /**
@@ -237,9 +244,8 @@ class Actions {
      *
      * @param {string} templateUrl - an S3 URL where the template will be saved
      * @param {string} templateBody - the CloudFormation template as a JSON string
-     * @param {function} callback - a function fired when the template has been saved
      */
-    static saveTemplate(templateUrl, templateBody, callback) {
+    static async saveTemplate(templateUrl, templateBody) {
         const uri = url.parse(templateUrl);
         const prefix = uri.host.replace(/^s3[-.]/, '').split('.');
         const region = prefix.length === 2 ? 'us-east-1' : prefix[0];
@@ -258,14 +264,15 @@ class Actions {
             Body: templateBody
         }, s3urls.fromUrl(templateUrl));
 
-        s3.putObject(params, (err) => {
-            if (err && err.code === 'NoSuchBucket')
-                return callback(new Actions.BucketNotFoundError('S3 bucket %s not found in %s', params.Bucket, region));
-            if (err)
-                return callback(new Actions.S3Error('%s: %s', err.code, err.message));
-
-            callback();
-        });
+        try {
+            await s3.putObject(params).promise();
+        } catch (err) {
+            if (err.code === 'NoSuchBucket') {
+                throw new Actions.BucketNotFoundError('S3 bucket %s not found in %s', params.Bucket, region);
+            } else {
+                throw new Actions.S3Error('%s: %s', err.code, err.message);
+            }
+        }
     }
 
     /**
@@ -319,36 +326,41 @@ class Actions {
  * @param {object} cfn - a cloudformation client object
  * @param {string} name - the name of the existing stack to update
  * @param {string} changesetId - the name or ARN of an existing changeset
- * @param {function} callback - a function that will be provided with the changeset
- * details once the changeset is in CREATE_COMPLETE, DELETE_COMPLETE, or FAILED state
  */
-function describeChangeset(cfn, name, changesetId, callback) {
+async function describeChangeset(cfn, name, changesetId) {
     let changesetDescriptions;
     let changes = [];
 
-    (function callAPI(nextToken, callback) {
-        cfn.describeChangeSet({
+    let nextToken = undefined;
+    do {
+        const data = await cfn.describeChangeSet({
             ChangeSetName: changesetId,
             StackName: name,
             NextToken: nextToken
-        }, (err, data) => {
-            if (err) return callback(err);
+        }).promise();
 
-            changesetDescriptions = data;
+        changesetDescriptions = data;
 
-            if (data.Status === 'CREATE_COMPLETE' || data.Status === 'FAILED' || data.status === 'DELETE_COMPLETE') {
-                changes = changes.concat(data.Changes || []);
+        if (data.Status === 'CREATE_COMPLETE' || data.Status === 'FAILED' || data.status === 'DELETE_COMPLETE') {
+            changes = changes.concat(data.Changes || []);
 
-                if (!data.NextToken) {
-                    if (changes.length) changesetDescriptions.Changes = changes;
-                    return callback(null, changesetDescriptions);
-                }
+            if (!data.NextToken) {
+                if (changes.length) changesetDescriptions.Changes = changes;
+                return changesetDescriptions;
             }
+        }
+        nextToken = data.NextToken;
 
-            setTimeout(callAPI, 1000, data.NextToken, callback);
-        });
-    })(undefined, callback);
+        await sleep(1000);
+    } while (nextToken);
 }
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 
 /**
  * Build ChangeSet object for CloudFormation requests

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -126,7 +126,7 @@ function parse(args, env) {
 
 async function main(parsed) {
     // Setup commands, make sure that CLI request uses a valid command
-    const available = new cfnConfig.Commands();
+    const available = new cfnConfig.Commands(parsed.options);
 
     if (!available[parsed.command])
         throw new Error('Error: invalid command\n\n' + parsed.help);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -124,19 +124,20 @@ function parse(args, env) {
     };
 }
 
-function main(parsed, callback) {
+async function main(parsed) {
     // Setup commands, make sure that CLI request uses a valid command
-    const available = cfnConfig.commands(parsed.options);
+    const available = new cfnConfig.Commands();
+
     if (!available[parsed.command])
-        return callback({ message: 'Error: invalid command\n\n' + parsed.help });
+        throw new Error('Error: invalid command\n\n' + parsed.help);
 
     // Check for valid environment
     if (!parsed.environment)
-        return callback({ message: 'Error: missing environment\n\n' + parsed.help });
+        throw new Error('Error: missing environment\n\n' + parsed.help);
 
     // Check for template path on create and update
     if (/create|update/.test(parsed.command) && !parsed.templatePath)
-        return callback({ message: 'Error: missing templatePath\n\n' + parsed.help });
+        throw new Error('Error: missing templatePath\n\n' + parsed.help);
 
     // Set the arguments for the command that will run
     const args = [parsed.environment];
@@ -152,8 +153,6 @@ function main(parsed, callback) {
 
     if (/create|update|delete/.test(parsed.command)) args.push(parsed.overrides);
 
-    args.push(callback);
-
     // Run the command
-    available[parsed.command].apply(null, args);
+    await available[parsed.command](...args);
 }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -223,7 +223,7 @@ class CommandContext {
 
     async run() {
         for (const op of this.operations) {
-            await operations(this);
+            await op(this);
         }
     }
 }
@@ -277,10 +277,9 @@ class Operations {
 
     static async getMasterConfig(context) {
         if (!context.overrides.masterConfig) return;
-        var s3Url = context.overrides.masterConfig;
 
-        const masterConfigJSON = await Lookup.defaultConfiguration(s3Url);
-        Object.keys(masterConfigJSON).forEach(async (key) => {
+        const masterConfigJSON = await Lookup.defaultConfiguration(context.overrides.masterConfig);
+        Object.keys(masterConfigJSON).forEach(async(key) => {
             if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
                 if (context.oldParameters[key].indexOf('secure') > -1) {
                     const kms = new AWS.KMS({
@@ -646,7 +645,8 @@ class Operations {
 
     static async getOldParameters(context) {
         try {
-            await Lookup.parameters(context.stackName, context.stackRegion);
+            let info await Lookup.parameters(context.stackName, context.stackRegion);
+            context.oldParameters = info;
         } catch (err) {
             let msg = '';
             if (err instanceof lookup.StackNotFoundError) msg += 'Missing stack: ';
@@ -655,33 +655,26 @@ class Operations {
             err.message = msg;
             throw err;
         }
-
-        context.oldParameters = info;
-
-        return;
     }
 
     static async promptSaveConfig(context) {
         const name = await Prompt.input('Name for saved configuration:', context.suffix);
         context.saveName = name;
-
-        return;
     }
 
     static async confirmSaveConfig(context) {
         process.stdout.write(stableStringify(context.oldParameters, { space: 2 }) + '\n\n');
         const ready = await Prompt.confirm('Ready to save this configuration as "' + context.saveName + '"?');
         if (!ready) throw new Error();
-
-        return;
     }
 
     static async saveConfig(context) {
         const kms = (context.overrides.kms && typeof context.overrides.kms !== 'string') ? 'alias/cloudformation' : context.overrides.kms;
         const maskedParameters = Object.assign({}, context.newParameters || {});
         const templateBody = context.newTemplate || {};
-        Object.keys(templateBody.Parameters || {}).forEach(function(name) {
-            var parameter = templateBody.Parameters[name];
+
+        Object.keys(templateBody.Parameters || {}).forEach((name) => {
+            const parameter = templateBody.Parameters[name];
             if (parameter.NoEcho) {
                 maskedParameters[name] = NOECHO_MASK;
             }
@@ -705,8 +698,6 @@ class Operations {
             err.message = msg;
             throw err;
         }
-
-        return;
     }
 
     static async mergeMetadata(context) {
@@ -719,10 +710,8 @@ class Operations {
                 context.newTemplate.Metadata[k] = context.overrides.metadata[k];
             }
         }
-
-        return;
     }
-};
+}
 
 function compare(existing, desired) {
     existing = JSON.parse(JSON.stringify(existing));
@@ -757,7 +746,7 @@ function compareTemplate(existing, desired) {
 
         let diffText = '';
 
-        strDiff.forEach(function(part, i){
+        strDiff.forEach((part, i) => {
             const color = part.added ? 'green' : part.removed ? 'red' : 'grey';
             const delimiter = '\n---------------------------------------------\n\n';
 
@@ -797,7 +786,7 @@ function formatDiff(details) {
         return msg;
     }
 
-    details.changes.forEach(function(change) {
+    details.changes.forEach((change) => {
         t.cell('Action', colors(change.action));
         t.cell('Name', colors(change.name));
         t.cell('Type', colors(change.type));
@@ -849,4 +838,4 @@ module.exports = {
     Commands,
     CommandContext,
     Operations
-}
+};

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -5,7 +5,7 @@ const jsonDiff = require('json-diff');
 const stableStringify = require('json-stable-stringify');
 const Diff = require('diff');
 const Table = require('easy-table');
-const actions = require('./actions');
+const Actions = require('./actions');
 const Lookup = require('./lookup');
 const Prompt = require('./prompt');
 const Template = require('./template');
@@ -46,6 +46,7 @@ require('colors');
 
 /**
  * Provides a set of commands for interacting with a CloudFormation stack
+ * @class
  *
  * @param {object} config
  * @param {string} config.name - the base name of the stack (no suffix)
@@ -53,16 +54,11 @@ require('colors');
  * @param {string} config.configBucket - the bucket that contains saved configurations
  * @param {string} config.templateBucket - the bucket where templates can be stored.
  * This bucket must be in the same region as the stack.
- * @returns {@link commands} commands - a set of functions for operating with CloudFormation templates
  */
-module.exports = function(config) {
-
-    /**
-     * Various high-level routines to interact with CloudFormation stacks
-     *
-     * @name commands
-     */
-    var commands = {};
+class Commands {
+    constructor(config) {
+        this.config = config;
+    }
 
     /**
      * Create a new CloudFormation stack. The user will be prompted to:
@@ -74,15 +70,9 @@ module.exports = function(config) {
      * @param {string} suffix - the trailing part of the new stack's name
      * @param {string} template - either the template as object or the filesystem path to the template file to load
      * @param {@link overrides} [overrides] - any overrides to the create flow
-     * @param {function} callback - a function fired when the stack has been created
      */
-    commands.create = function(suffix, template, overrides, callback) {
-        if (typeof overrides === 'function') {
-            callback = overrides;
-            overrides = {};
-        }
-
-        var context = module.exports.commandContext(config, suffix, [
+    async create(suffix, template, overrides={}) {
+        var context = commandContext(this.config, suffix, [
             operations.createPreamble,
             operations.selectConfig,
             operations.loadConfig,
@@ -101,7 +91,7 @@ module.exports = function(config) {
         context.overrides = overrides;
         context.template = template;
         context.next();
-    };
+    }
 
     /**
      * Update an existing CloudFormation stack. The user will be prompted to:
@@ -115,14 +105,8 @@ module.exports = function(config) {
      * @param {string} suffix - the trailing part of the new stack's name
      * @param {string} template - either the template as object or the filesystem path to the template file to load
      * @param {@link overrides} [overrides] - any overrides to the create flow
-     * @param {function} callback - a function fired when the stack has been updated
      */
-    commands.update = function(suffix, template, overrides, callback) {
-        if (typeof overrides === 'function') {
-            callback = overrides;
-            overrides = {};
-        }
-
+    async update(suffix, template, overrides={}) {
         var operationsArray = [
             operations.updatePreamble,
             operations.getMasterConfig,
@@ -141,12 +125,12 @@ module.exports = function(config) {
             operations.saveConfig
         ];
 
-        var context = module.exports.commandContext(config, suffix, operationsArray, callback);
+        var context = commandContext(config, suffix, operationsArray, callback);
 
         context.overrides = overrides;
         context.template = template;
         context.next();
-    };
+    }
 
     /**
      * Delete an existing CloudFormation stack. The user will be prompted to:
@@ -155,15 +139,9 @@ module.exports = function(config) {
      *
      * @param {string} suffix - the trailing part of the existing stack's name
      * @param {@link overrides} [overrides] - any overrides to the create flow
-     * @param {function} callback - a function fired when the stack has been updated
      */
-    commands.delete = function(suffix, overrides, callback) {
-        if (typeof overrides === 'function') {
-            callback = overrides;
-            overrides = {};
-        }
-
-        var context = module.exports.commandContext(config, suffix, [
+    async delete(suffix, overrides={}) {
+        var context = commandContext(config, suffix, [
             operations.confirmDelete,
             operations.deleteStack,
             operations.monitorStack
@@ -171,7 +149,7 @@ module.exports = function(config) {
 
         context.overrides = overrides;
         context.next();
-    };
+    }
 
     /**
      * Lookup information about an existing stack.
@@ -181,9 +159,9 @@ module.exports = function(config) {
      * will include details of each resource in the stack
      * @param {boolean} [decrypt=false] - return secure parameters decrypted
      */
-    commands.info = async function(suffix, resources=false, decrypt=false) {
-        await lookup.info(stackName(config.name, suffix), config.region, resources, decrypt);
-    };
+    async info(suffix, resources=false, decrypt=false) {
+        await Lookup.info(stackName(config.name, suffix), config.region, resources, decrypt);
+    }
 
     /**
      * Save an existing stack's parameter values to S3. The user will be prompted
@@ -193,16 +171,14 @@ module.exports = function(config) {
      * @param {string} suffix - the trailing part of the new stack's name
      * @param {string|boolean} [kms=false] - if specified, this KMS key id will
      * be used to encrypt the contents of the file at-rest on S3.
-     * @param {function} callback - a function fired when the configuration has
-     * been saved
      */
-    commands.save = function(suffix, kms, callback) {
+    async save(suffix, kms) {
         if (typeof kms === 'function') {
             callback = kms;
             kms = false;
         }
 
-        var context = module.exports.commandContext(config, suffix, [
+        var context = commandContext(config, suffix, [
             operations.getOldParameters,
             operations.promptSaveConfig,
             operations.confirmSaveConfig,
@@ -211,10 +187,8 @@ module.exports = function(config) {
 
         context.kms = kms;
         context.next();
-    };
-
-    return commands;
-};
+    }
+}
 
 /**
  * Generates context for high-level functions and steps through the defined operations.
@@ -227,7 +201,7 @@ module.exports = function(config) {
  * @param {function} callback - a function fired when all operations are complete
  * @return {object} context - information passed from operation to operation
  */
-module.exports.commandContext = (config, suffix, operations, callback) => {
+function commandContext(config, suffix, operations, callback) {
     let i = -1;
 
     const context = {
@@ -253,7 +227,7 @@ module.exports.commandContext = (config, suffix, operations, callback) => {
     };
 
     return context;
-};
+}
 
 /**
  * Individual operations that are composed into high-level commands. Each function
@@ -305,7 +279,7 @@ const operations = module.exports.operations = {
         if (!context.overrides.masterConfig) return context.next();
         var s3Url = context.overrides.masterConfig;
 
-        lookup.defaultConfiguration(s3Url, (err, masterConfigJSON) => {
+        Lookup.defaultConfiguration(s3Url, (err, masterConfigJSON) => {
             if (err) return context.abort();
             Object.keys(masterConfigJSON).forEach((key) => {
                 if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
@@ -441,20 +415,21 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    saveTemplate: function(context) {
+    saveTemplate: async function(context) {
         context.templateUrl = actions.templateUrl(context.templateBucket, context.stackRegion, context.suffix);
-        actions.saveTemplate(context.templateUrl, stableStringify(context.newTemplate, { space: 2 }), function(err) {
-            if (err) {
-                var msg = '';
-                if (err instanceof actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
-                if (err instanceof actions.S3Error) msg += 'Failed to save template: ';
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
 
-            context.next();
-        });
+        try {
+            await Actions.saveTemplate(context.templateUrl, stableStringify(context.newTemplate, { space: 2 }));
+        } catch (err) {
+            let msg = '';
+            if (err instanceof Actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
+            if (err instanceof Actions.S3Error) msg += 'Failed to save template: ';
+            msg += err.message;
+            err.message = msg;
+            return context.abort(err);
+        }
+
+        context.next();
     },
 
     validateTemplate: function(context) {
@@ -853,3 +828,5 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
         return parameter;
     });
 }
+
+module.exports = Commands;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -260,8 +260,8 @@ class Operations {
                 var msg = '';
                 if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
                 if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
-                if (err instanceof lookup.StackNotFoundError) msg += 'Missing stack: ';
-                if (err instanceof lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
+                if (err instanceof Lookup.StackNotFoundError) msg += 'Missing stack: ';
+                if (err instanceof Lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
                 msg += err.message;
                 err.message = msg;
                 throw err;
@@ -548,8 +548,8 @@ class Operations {
                 var msg = '';
                 if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
                 if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
-                if (err instanceof lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
-                if (err instanceof lookup.S3Error) msg += 'Could not load saved configurations: ';
+                if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
+                if (err instanceof Lookup.S3Error) msg += 'Could not load saved configurations: ';
                 msg += err.message;
                 err.message = msg;
                 throw err;
@@ -574,31 +574,39 @@ class Operations {
     }
 
     static async loadConfig(context) {
-        function finished(err, info) {
-            if (err) {
-                var msg = '';
-                if (err instanceof lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
-                if (err instanceof lookup.ConfigurationNotFoundError) msg += 'Could not find saved configuration: ';
-                if (err instanceof lookup.InvalidConfigurationError) msg += 'Saved configuration error: ';
-                if (err instanceof lookup.S3Error) msg += 'Failed to read saved configuration: ';
-                msg += err.message;
-                err.message = msg;
-                throw err;
-            }
-
-            context.oldParameters = info;
-            return;
-        }
-
         if (!context.configName) {
             if (context.overrides.defaultConfig) {
-                return lookup.defaultConfiguration(context.overrides.defaultConfig, finished);
+                try {
+                    const info = await Lookup.defaultConfiguration(context.overrides.defaultConfig);
+                    context.oldParameters = info;
+                } catch (err){
+                    var msg = '';
+                    if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
+                    if (err instanceof Lookup.ConfigurationNotFoundError) msg += 'Could not find saved configuration: ';
+                    if (err instanceof Lookup.InvalidConfigurationError) msg += 'Saved configuration error: ';
+                    if (err instanceof Lookup.S3Error) msg += 'Failed to read saved configuration: ';
+                    msg += err.message;
+                    err.message = msg;
+                    throw err;
+                }
             } else {
                 return;
             }
         }
 
-        lookup.configuration(context.baseName, context.configBucket, context.configName, finished);
+        try {
+            const info = await Lookup.configuration(context.baseName, context.configBucket, context.configName);
+            context.oldParameters = info;
+        } catch (err){
+            var msg = '';
+            if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
+            if (err instanceof Lookup.ConfigurationNotFoundError) msg += 'Could not find saved configuration: ';
+            if (err instanceof Lookup.InvalidConfigurationError) msg += 'Saved configuration error: ';
+            if (err instanceof Lookup.S3Error) msg += 'Failed to read saved configuration: ';
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
     }
 
     static async confirmCreate(context) {
@@ -645,12 +653,12 @@ class Operations {
 
     static async getOldParameters(context) {
         try {
-            let info await Lookup.parameters(context.stackName, context.stackRegion);
+            let info = await Lookup.parameters(context.stackName, context.stackRegion);
             context.oldParameters = info;
         } catch (err) {
             let msg = '';
-            if (err instanceof lookup.StackNotFoundError) msg += 'Missing stack: ';
-            if (err instanceof lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
+            if (err instanceof Lookup.StackNotFoundError) msg += 'Missing stack: ';
+            if (err instanceof Lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
             msg += err.message;
             err.message = msg;
             throw err;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -409,7 +409,7 @@ class Operations {
     },
 
     static async saveTemplate(context) {
-        context.templateUrl = actions.templateUrl(context.templateBucket, context.stackRegion, context.suffix);
+        context.templateUrl = Actions.templateUrl(context.templateBucket, context.stackRegion, context.suffix);
 
         try {
             await Actions.saveTemplate(context.templateUrl, stableStringify(context.newTemplate, { space: 2 }));
@@ -419,24 +419,24 @@ class Operations {
             if (err instanceof Actions.S3Error) msg += 'Failed to save template: ';
             msg += err.message;
             err.message = msg;
-            return context.abort(err);
+            throw err;
         }
 
-        context.next();
-    },
+        return;
+    }
 
     static async validateTemplate(context) {
-        actions.validate(context.stackRegion, context.templateUrl, function(err) {
-            if (err) {
-                var msg = 'Invalid template: '; // err instanceof actions.CloudFormationError
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
+        try {
+            await Actions.validate(context.stackRegion, context.templateUrl);
+        } catch (err) {
+            let msg = 'Invalid template: '; // err instanceof Actions.CloudFormationError
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
 
-            context.next();
-        });
-    },
+        return;
+    }
 
     static async validateParametersHook(context) {
         if (!context.overrides.validateParameters) return context.next();
@@ -465,27 +465,25 @@ class Operations {
     }
 
     static async getChangeset(context, changeSetType) {
-        function finished(err, details) {
-            if (err) {
-                var msg = 'Failed to generate changeset: '; // err instanceof actions.CloudFormationError
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
-
-            context.changeset = details;
-            context.next();
+        try {
+            const details = await Actions.diff(
+                context.stackName,
+                context.stackRegion,
+                changeSetType,
+                context.templateUrl,
+                context.changesetParameters,
+                context.overrides.expand,
+            );
+        } catch (err) {
+            let msg = 'Failed to generate changeset: '; // err instanceof Actions.CloudFormationError
+            msg += err.message;
+            err.message = msg;
+            throw err;
         }
 
-        actions.diff(
-            context.stackName,
-            context.stackRegion,
-            changeSetType,
-            context.templateUrl,
-            context.changesetParameters,
-            context.overrides.expand,
-            finished
-        );
+        context.changeset = details;
+
+        return;
     },
 
     static async confirmChangeset(context) {
@@ -505,11 +503,11 @@ class Operations {
 
     static async executeChangeSet(context) {
         try {
-            Actions.executeChangeSet(context.stackName, context.stackRegion, context.changeset.id);
+            await Actions.executeChangeSet(context.stackName, context.stackRegion, context.changeset.id);
         } catch (err) {
             let msg = '';
-            if (err instanceof actions.CloudFormationError) msg += 'Failed to execute changeset: ';
-            if (err instanceof actions.ChangeSetNotExecutableError) msg += 'Status: ' + err.execution + ' | Reason: ' + err.reason + ' | ';
+            if (err instanceof Actions.CloudFormationError) msg += 'Failed to execute changeset: ';
+            if (err instanceof Actions.ChangeSetNotExecutableError) msg += 'Status: ' + err.execution + ' | Reason: ' + err.reason + ' | ';
             msg += err.message;
             err.message = msg;
             throw err;
@@ -612,7 +610,7 @@ class Operations {
         try {
             await Actions.delete(context.stackName, context.stackRegion);
         } catch (err) {
-            let msg = 'Failed to delete stack: '; // err instanceof actions.CloudFormationError
+            let msg = 'Failed to delete stack: '; // err instanceof Actions.CloudFormationError
             msg += err.message;
             err.message = msg;
 
@@ -677,7 +675,7 @@ class Operations {
 
 
         try {
-            await actions.saveConfiguration(
+            await Actions.saveConfiguration(
                 context.baseName,
                 context.stackName,
                 context.stackRegion,
@@ -687,8 +685,8 @@ class Operations {
             );
         } catch (err) {
             let msg = '';
-            if (err instanceof actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
-            if (err instanceof actions.S3Error) msg += 'Failed to save template: ';
+            if (err instanceof Actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
+            if (err instanceof Actions.S3Error) msg += 'Failed to save template: ';
             msg += err.message;
             err.message = msg;
             throw err;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -275,7 +275,8 @@ class Operations {
         if (!context.overrides.masterConfig) return;
 
         const masterConfigJSON = await Lookup.defaultConfiguration(context.overrides.masterConfig);
-        Object.keys(masterConfigJSON).forEach(async(key) => {
+
+        for (const key of Object.keys(masterConfigJSON)) {
             if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
                 if (context.oldParameters[key].includes('secure')) {
                     const kms = new AWS.KMS({
@@ -284,6 +285,7 @@ class Operations {
                     });
 
                     const valueToDecrypt = context.oldParameters[key].replace(/^secure:/, '');
+
                     const data = await kms.decrypt({
                         CiphertextBlob: new Buffer.from(valueToDecrypt, 'base64')
                     }).promise();
@@ -295,7 +297,7 @@ class Operations {
                     }
                 }
             }
-        });
+        }
 
         return;
     }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -72,7 +72,7 @@ class Commands {
      * @param {@link overrides} [overrides] - any overrides to the create flow
      */
     async create(suffix, template, overrides={}) {
-        var context = commandContext(this.config, suffix, [
+        const context = new CommandContext(this.config, suffix, [
             operations.createPreamble,
             operations.selectConfig,
             operations.loadConfig,
@@ -86,11 +86,12 @@ class Commands {
             operations.executeChangeSet,
             operations.monitorStack,
             operations.saveConfig
-        ], callback);
+        ]);
 
         context.overrides = overrides;
         context.template = template;
-        context.next();
+
+        await context.run();
     }
 
     /**
@@ -107,7 +108,7 @@ class Commands {
      * @param {@link overrides} [overrides] - any overrides to the create flow
      */
     async update(suffix, template, overrides={}) {
-        var operationsArray = [
+        const context = new CommandContext(this.config, suffix, [
             operations.updatePreamble,
             operations.getMasterConfig,
             operations.promptParameters,
@@ -123,13 +124,12 @@ class Commands {
             operations.executeChangeSet,
             operations.monitorStack,
             operations.saveConfig
-        ];
-
-        var context = commandContext(config, suffix, operationsArray, callback);
+        ]);
 
         context.overrides = overrides;
         context.template = template;
-        context.next();
+
+        await context.run();
     }
 
     /**
@@ -141,14 +141,15 @@ class Commands {
      * @param {@link overrides} [overrides] - any overrides to the create flow
      */
     async delete(suffix, overrides={}) {
-        var context = commandContext(config, suffix, [
+        const context = new CommandContext(this.config, suffix, [
             operations.confirmDelete,
             operations.deleteStack,
             operations.monitorStack
-        ], callback);
+        ]);
 
         context.overrides = overrides;
-        context.next();
+
+        await context.run();
     }
 
     /**
@@ -172,61 +173,52 @@ class Commands {
      * @param {string|boolean} [kms=false] - if specified, this KMS key id will
      * be used to encrypt the contents of the file at-rest on S3.
      */
-    async save(suffix, kms) {
-        if (typeof kms === 'function') {
-            callback = kms;
-            kms = false;
-        }
-
-        var context = commandContext(config, suffix, [
+    async save(suffix, kms=false) {
+        const context = new CommandContext(this.config, suffix, [
             operations.getOldParameters,
             operations.promptSaveConfig,
             operations.confirmSaveConfig,
             operations.saveConfig
-        ], callback);
+        ]);
 
         context.kms = kms;
-        context.next();
+
+        await context.run();
     }
 }
 
 /**
  * Generates context for high-level functions and steps through the defined operations.
  *
+ * @class
  * @private
  * @param {object} config - configurations options provided to the commands factory
  * @param {string} suffix - the trailing part of a stack's name
  * @param {array} operations - and array of operation functions that will be
  * called in order to build the desired deployment flow.
- * @param {function} callback - a function fired when all operations are complete
- * @return {object} context - information passed from operation to operation
  */
-function commandContext(config, suffix, operations, callback) {
-    let i = -1;
+class CommandContext {
+    constructor(config, suffix, operations)  {
+        this.baseName = config.name;
+        this.suffix = suffix;
+        this.stackName = stackName(config.name, suffix);
+        this.stackRegion = config.region;
+        this.configBucket = config.configBucket;
+        this.templateBucket = config.templateBucket;
+        this.overrides = {};
+        this.oldParameters = {};
+        this.diffs = {};
 
-    const context = {
-        baseName: config.name,
-        suffix: suffix,
-        stackName: stackName(config.name, suffix),
-        stackRegion: config.region,
-        configBucket: config.configBucket,
-        templateBucket: config.templateBucket,
-        overrides: {},
-        oldParameters: {},
-        diffs: {},
-        abort: (err) => {
-            if (err) callback(err, false);
-            else callback(null, false);
-        },
-        next: () => {
-            i++;
-            const operation = operations[i];
-            if (!operation) return callback(null, true, context.diffs);
-            operation(context);
+        this.operations = operations;
+    }
+
+    async run() {
+        for (const op of this.operations) {
+            await operations(this);
         }
-    };
 
-    return context;
+        return this.diffs;
+    }
 }
 
 /**

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -9,7 +9,6 @@ const Actions = require('./actions');
 const Lookup = require('./lookup');
 const Prompt = require('./prompt');
 const Template = require('./template');
-const d3 = require('d3-queue');
 const AWS = require('aws-sdk');
 
 const NOECHO_MASK = '****';
@@ -238,41 +237,31 @@ class CommandContext {
  */
 class Operations {
     static async updatePreamble(context) {
-        var preamble = d3.queue();
-
-        if (!context.template) {
-            preamble.defer((next) => next(new Template.NotFoundError('No template passed')));
-        } else if (typeof context.template === 'string') {
-            preamble.defer(
-                Template.read,
-                path.resolve(context.template),
-                context.overrides.templateOptions
-            );
-        } else {
-            // we assume if template is not string, it's a pre-loaded template body object
-            preamble.defer((next) => next(null, context.template));
-        }
-
-        preamble.defer(lookup.parameters, context.stackName, context.stackRegion);
-        preamble.defer(lookup.template, context.stackName, context.stackRegion);
-        preamble.await(function(err, templateBody, oldParams, oldTemplate) {
-            if (err) {
-                var msg = '';
-                if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
-                if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
-                if (err instanceof Lookup.StackNotFoundError) msg += 'Missing stack: ';
-                if (err instanceof Lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
-                msg += err.message;
-                err.message = msg;
-                throw err;
+        try {
+            if (!context.template) {
+                throw new Template.NotFoundError('No template passed');
+            } else if (typeof context.template === 'string') {
+                context.newTemplate = await Template.read(
+                    path.resolve(context.template),
+                    context.overrides.templateOptions
+                );
+            } else {
+                // we assume if template is not string, it's a pre-loaded template body object
+                context.newTemplate = context.template;
             }
 
-            context.newTemplate = templateBody;
-            context.oldTemplate = oldTemplate;
-            context.oldParameters = oldParams;
-
-            return;
-        });
+            context.oldParameters = await Lookup.parameters(context.stackName, context.stackRegion);
+            context.oldTemplate = await Lookup.template(context.stackName, context.stackRegion);
+        } catch (err) {
+            let msg = '';
+            if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
+            if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
+            if (err instanceof Lookup.StackNotFoundError) msg += 'Missing stack: ';
+            if (err instanceof Lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
     }
 
     static async getMasterConfig(context) {
@@ -398,7 +387,7 @@ class Operations {
         }
 
         if (context.overrides.preapproved && context.overrides.preapproved.template) {
-            const preapproved = context.overrides.preapproved.template.filter(function(previous) {
+            const preapproved = context.overrides.preapproved.template.filter((previous) => {
                 return previous === diff;
             }).length;
 
@@ -499,7 +488,7 @@ class Operations {
             return;
         }
 
-        var msg = [
+        const msg = [
             formatDiff(context.changeset),
             'Accept changes and update the stack?'
         ].join('\n');
@@ -526,40 +515,29 @@ class Operations {
     }
 
     static async createPreamble(context) {
-        var preamble = d3.queue();
         context.create = true;
 
-        if (!context.template) {
-            preamble.defer((next) => next(new Template.NotFoundError('No template passed')));
-        } else if (typeof context.template === 'string') {
-            preamble.defer(
-                Template.read,
-                path.resolve(context.template),
-                context.overrides.templateOptions
-            );
-        } else {
-            // we assume if template is not string, it's a pre-loaded template body object
-            preamble.defer((next) => next(null, context.template));
-        }
-
-        preamble.defer(lookup.configurations, context.baseName, context.configBucket, context.stackRegion);
-        preamble.await(function(err, templateBody, configs) {
-            if (err) {
-                var msg = '';
-                if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
-                if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
-                if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
-                if (err instanceof Lookup.S3Error) msg += 'Could not load saved configurations: ';
-                msg += err.message;
-                err.message = msg;
-                throw err;
+        try {
+            if (!context.template) {
+                throw new Template.NotFoundError('No template passed');
+            } else if (typeof context.template === 'string') {
+                context.newTemplate = await Template.read(path.resolve(context.template), context.overrides.templateOptions);
+            } else {
+                // we assume if template is not string, it's a pre-loaded template body object
+                context.newTemplate = context.template;
             }
 
-            context.newTemplate = templateBody;
-            context.configNames = configs;
-
-            return;
-        });
+            context.configNames = await Lookup.configurations(context.baseName, context.configBucket, context.stackRegion);
+        } catch (err) {
+            let msg = '';
+            if (err instanceof Template.NotFoundError) msg += 'Could not load template: ';
+            if (err instanceof Template.InvalidTemplateError) msg += 'Could not parse template: ';
+            if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
+            if (err instanceof Lookup.S3Error) msg += 'Could not load saved configurations: ';
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
     }
 
     static async selectConfig(context) {
@@ -580,7 +558,7 @@ class Operations {
                     const info = await Lookup.defaultConfiguration(context.overrides.defaultConfig);
                     context.oldParameters = info;
                 } catch (err){
-                    var msg = '';
+                    let msg = '';
                     if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
                     if (err instanceof Lookup.ConfigurationNotFoundError) msg += 'Could not find saved configuration: ';
                     if (err instanceof Lookup.InvalidConfigurationError) msg += 'Saved configuration error: ';
@@ -598,7 +576,7 @@ class Operations {
             const info = await Lookup.configuration(context.baseName, context.configBucket, context.configName);
             context.oldParameters = info;
         } catch (err){
-            var msg = '';
+            let msg = '';
             if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
             if (err instanceof Lookup.ConfigurationNotFoundError) msg += 'Could not find saved configuration: ';
             if (err instanceof Lookup.InvalidConfigurationError) msg += 'Saved configuration error: ';

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -57,7 +57,7 @@ require('colors');
  * @param {boolean} dryrun Used by the tests to return the context without running
  */
 class Commands {
-    constructor(config, dryrun=false) {
+    constructor(config={}, dryrun=false) {
         this.config = config;
         this.dryrun = dryrun;
     }
@@ -819,8 +819,6 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
     });
 }
 
-module.exports = {
-    Commands,
-    CommandContext,
-    Operations
-};
+module.exports.Commands = Commands;
+module.exports.CommandContext = CommandContext;
+module.exports.Operations = Operations;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -216,6 +216,7 @@ class CommandContext {
         this.overrides = {};
         this.oldParameters = {};
         this.diffs = {};
+        this.kms = false;
 
         this.operations = operations;
     }
@@ -278,7 +279,7 @@ class Operations {
 
         for (const key of Object.keys(masterConfigJSON)) {
             if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
-                if (context.oldParameters[key].includes('secure')) {
+                if (context.kms && context.oldParameters[key].includes('secure')) {
                     const kms = new AWS.KMS({
                         region: context.stackRegion,
                         maxRetries: 10

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -73,19 +73,19 @@ class Commands {
      */
     async create(suffix, template, overrides={}) {
         const context = new CommandContext(this.config, suffix, [
-            operations.createPreamble,
-            operations.selectConfig,
-            operations.loadConfig,
-            operations.promptParameters,
-            operations.validateParametersHook,
-            operations.confirmCreate,
-            operations.mergeMetadata,
-            operations.saveTemplate,
-            operations.validateTemplate,
-            operations.getChangesetCreate,
-            operations.executeChangeSet,
-            operations.monitorStack,
-            operations.saveConfig
+            Operations.createPreamble,
+            Operations.selectConfig,
+            Operations.loadConfig,
+            Operations.promptParameters,
+            Operations.validateParametersHook,
+            Operations.confirmCreate,
+            Operations.mergeMetadata,
+            Operations.saveTemplate,
+            Operations.validateTemplate,
+            Operations.getChangesetCreate,
+            Operations.executeChangeSet,
+            Operations.monitorStack,
+            Operations.saveConfig
         ]);
 
         context.overrides = overrides;
@@ -109,21 +109,21 @@ class Commands {
      */
     async update(suffix, template, overrides={}) {
         const context = new CommandContext(this.config, suffix, [
-            operations.updatePreamble,
-            operations.getMasterConfig,
-            operations.promptParameters,
-            operations.confirmParameters,
-            operations.validateParametersHook,
-            operations.mergeMetadata,
-            operations.confirmTemplate,
-            operations.saveTemplate,
-            operations.validateTemplate,
-            operations.beforeUpdateHook,
-            operations.getChangesetUpdate,
-            operations.confirmChangeset,
-            operations.executeChangeSet,
-            operations.monitorStack,
-            operations.saveConfig
+            Operations.updatePreamble,
+            Operations.getMasterConfig,
+            Operations.promptParameters,
+            Operations.confirmParameters,
+            Operations.validateParametersHook,
+            Operations.mergeMetadata,
+            Operations.confirmTemplate,
+            Operations.saveTemplate,
+            Operations.validateTemplate,
+            Operations.beforeUpdateHook,
+            Operations.getChangesetUpdate,
+            Operations.confirmChangeset,
+            Operations.executeChangeSet,
+            Operations.monitorStack,
+            Operations.saveConfig
         ]);
 
         context.overrides = overrides;
@@ -142,9 +142,9 @@ class Commands {
      */
     async delete(suffix, overrides={}) {
         const context = new CommandContext(this.config, suffix, [
-            operations.confirmDelete,
-            operations.deleteStack,
-            operations.monitorStack
+            Operations.confirmDelete,
+            Operations.deleteStack,
+            Operations.monitorStack
         ]);
 
         context.overrides = overrides;
@@ -175,10 +175,10 @@ class Commands {
      */
     async save(suffix, kms=false) {
         const context = new CommandContext(this.config, suffix, [
-            operations.getOldParameters,
-            operations.promptSaveConfig,
-            operations.confirmSaveConfig,
-            operations.saveConfig
+            Operations.getOldParameters,
+            Operations.promptSaveConfig,
+            Operations.confirmSaveConfig,
+            Operations.saveConfig
         ]);
 
         context.kms = kms;
@@ -227,9 +227,10 @@ class CommandContext {
  * if some failure occurred.
  *
  * @private
+ * @class
  */
-const operations = module.exports.operations = {
-    updatePreamble: function(context) {
+class Operations {
+    static async updatePreamble(context) {
         var preamble = d3.queue();
 
         if (!context.template) {
@@ -263,44 +264,43 @@ const operations = module.exports.operations = {
             context.oldTemplate = oldTemplate;
             context.oldParameters = oldParams;
 
-            context.next();
+            return;
         });
     },
 
-    getMasterConfig: function(context) {
-        if (!context.overrides.masterConfig) return context.next();
+    static async getMasterConfig(context) {
+        if (!context.overrides.masterConfig) return;
         var s3Url = context.overrides.masterConfig;
 
-        Lookup.defaultConfiguration(s3Url, (err, masterConfigJSON) => {
-            if (err) return context.abort();
-            Object.keys(masterConfigJSON).forEach((key) => {
-                if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
-                    if (context.oldParameters[key].indexOf('secure') > -1) {
-                        var kms = new AWS.KMS({
-                            region: context.stackRegion,
-                            maxRetries: 10
-                        });
-                        var valueToDecrypt = context.oldParameters[key].replace(/^secure:/, '');
-                        kms.decrypt({
-                            CiphertextBlob: new Buffer(valueToDecrypt, 'base64')
-                        }, (err, data) => {
-                            if (err) return context.abort();
-                            var decryptedOldParams = new Buffer(data.Plaintext, 'base64').toString('utf-8');
-                            var decryptedMaster = masterConfigJSON[key];
-                            if (decryptedOldParams !== decryptedMaster) {
-                                context.oldParameters[key] = masterConfigJSON[key];
-                            }
-                        });
+        const masterConfigJSON = await Lookup.defaultConfiguration(s3Url);
+        Object.keys(masterConfigJSON).forEach((key) => {
+            if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
+                if (context.oldParameters[key].indexOf('secure') > -1) {
+                    const kms = new AWS.KMS({
+                        region: context.stackRegion,
+                        maxRetries: 10
+                    });
+
+                    const valueToDecrypt = context.oldParameters[key].replace(/^secure:/, '');
+                    const data = await kms.decrypt({
+                        CiphertextBlob: new Buffer(valueToDecrypt, 'base64')
+                    }).promise();
+
+                    const decryptedOldParams = new Buffer(data.Plaintext, 'base64').toString('utf-8');
+                    const decryptedMaster = masterConfigJSON[key];
+                    if (decryptedOldParams !== decryptedMaster) {
+                        context.oldParameters[key] = masterConfigJSON[key];
                     }
                 }
-            });
-            context.next();
+            }
         });
+
+        return;
     },
 
-    promptParameters: async function(context) {
-        var newTemplateParameters = context.newTemplate.Parameters || {};
-        var overrideParameters = {};
+    static async promptParameters(context) {
+        const newTemplateParameters = context.newTemplate.Parameters || {};
+        const overrideParameters = {};
 
         if (context.overrides.parameters) {
             Object.keys(context.overrides.parameters).forEach(function(key){
@@ -329,7 +329,7 @@ const operations = module.exports.operations = {
             Object.assign(context.oldParameters, overrideParameters);
         }
 
-        var questions = Template.questions(context.newTemplate, {
+        const questions = Template.questions(context.newTemplate, {
             defaults: context.oldParameters,
             region: context.stackRegion,
             kmsKeyId: context.overrides.kms
@@ -344,10 +344,11 @@ const operations = module.exports.operations = {
             overrideParameters,
             context.create
         );
-        context.next();
+
+        return;
     },
 
-    confirmParameters: async function(context) {
+    static async confirmParameters(context) {
         if (context.overrides.force || context.overrides.skipConfirmParameters) {
             return context.next();
         }
@@ -377,7 +378,7 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    confirmTemplate: async function(context) {
+    static async confirmTemplate(context) {
         if (context.overrides.force || context.overrides.skipConfirmTemplate) {
             return context.next();
         }
@@ -407,7 +408,7 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    saveTemplate: async function(context) {
+    static async saveTemplate(context) {
         context.templateUrl = actions.templateUrl(context.templateBucket, context.stackRegion, context.suffix);
 
         try {
@@ -424,7 +425,7 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    validateTemplate: function(context) {
+    static async validateTemplate(context) {
         actions.validate(context.stackRegion, context.templateUrl, function(err) {
             if (err) {
                 var msg = 'Invalid template: '; // err instanceof actions.CloudFormationError
@@ -437,7 +438,7 @@ const operations = module.exports.operations = {
         });
     },
 
-    validateParametersHook: function(context) {
+    static async validateParametersHook(context) {
         if (!context.overrides.validateParameters) return context.next();
 
         context.overrides.validateParameters(context, function(err) {
@@ -446,7 +447,7 @@ const operations = module.exports.operations = {
         });
     },
 
-    beforeUpdateHook: function(context) {
+    static async beforeUpdateHook(context) {
         if (!context.overrides.beforeUpdate) return context.next();
 
         context.overrides.beforeUpdate(context, function(err) {
@@ -455,15 +456,15 @@ const operations = module.exports.operations = {
         });
     },
 
-    getChangesetCreate: function(context) {
+    static async getChangesetCreate(context) {
         operations.getChangeset(context, 'CREATE');
-    },
+    }
 
-    getChangesetUpdate: function(context) {
+    static async getChangesetUpdate(context) {
         operations.getChangeset(context, 'UPDATE');
-    },
+    }
 
-    getChangeset: function(context, changeSetType) {
+    static async getChangeset(context, changeSetType) {
         function finished(err, details) {
             if (err) {
                 var msg = 'Failed to generate changeset: '; // err instanceof actions.CloudFormationError
@@ -487,7 +488,7 @@ const operations = module.exports.operations = {
         );
     },
 
-    confirmChangeset: async function(context) {
+    static async confirmChangeset(context) {
         if (context.overrides.force || (context.overrides.skipConfirmTemplate && context.overrides.skipConfirmParameters)) {
             return context.next();
         }
@@ -502,22 +503,22 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    executeChangeSet: function(context) {
-        actions.executeChangeSet(context.stackName, context.stackRegion, context.changeset.id, function(err) {
-            if (err) {
-                var msg = '';
-                if (err instanceof actions.CloudFormationError) msg += 'Failed to execute changeset: ';
-                if (err instanceof actions.ChangeSetNotExecutableError) msg += 'Status: ' + err.execution + ' | Reason: ' + err.reason + ' | ';
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
+    static async executeChangeSet(context) {
+        try {
+            Actions.executeChangeSet(context.stackName, context.stackRegion, context.changeset.id);
+        } catch (err) {
+            let msg = '';
+            if (err instanceof actions.CloudFormationError) msg += 'Failed to execute changeset: ';
+            if (err instanceof actions.ChangeSetNotExecutableError) msg += 'Status: ' + err.execution + ' | Reason: ' + err.reason + ' | ';
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
 
-            context.next();
-        });
+        return;
     },
 
-    createPreamble: function(context) {
+    static async createPreamble(context) {
         var preamble = d3.queue();
         context.create = true;
 
@@ -553,17 +554,18 @@ const operations = module.exports.operations = {
         });
     },
 
-    selectConfig: async function(context) {
-        if (context.overrides.force) return context.next();
+    static async selectConfig(context) {
+        if (context.overrides.force) return;
 
         const savedConfig = await Prompt.configuration(context.configNames);
-        if (savedConfig === 'New configuration') return context.next();
+        if (savedConfig === 'New configuration') return;
 
         context.configName = savedConfig;
-        context.next();
+
+        return;
     },
 
-    loadConfig: function(context) {
+    static async loadConfig(context) {
         function finished(err, info) {
             if (err) {
                 var msg = '';
@@ -588,77 +590,81 @@ const operations = module.exports.operations = {
         lookup.configuration(context.baseName, context.configBucket, context.configName, finished);
     },
 
-    confirmCreate: async function(context) {
-        if (context.overrides.force) return context.next();
+    static async confirmCreate(context) {
+        if (context.overrides.force) return;
 
         const ready = await Prompt.confirm('Ready to create the stack?');
-        if (!ready) return context.abort();
-        context.next();
+        if (!ready) throw new Error();
+
+        return;
     },
 
-    confirmDelete: async function(context) {
+    static async confirmDelete(context) {
         if (context.overrides.force) return context.next();
         const msg = 'Are you sure you want to delete ' + context.stackName + ' in region ' + context.stackRegion + '?';
         const ready = await Prompt.confirm(msg, false);
-        if (!ready) return context.abort();
-        context.next();
+        if (!ready) throw new Error();
+
+        return;
     },
 
-    deleteStack: function(context) {
-        actions.delete(context.stackName, context.stackRegion, function(err) {
-            if (err) {
-                var msg = 'Failed to delete stack: '; // err instanceof actions.CloudFormationError
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
+    static async deleteStack(context) {
+        try {
+            await Actions.delete(context.stackName, context.stackRegion);
+        } catch (err) {
+            let msg = 'Failed to delete stack: '; // err instanceof actions.CloudFormationError
+            msg += err.message;
+            err.message = msg;
 
-            context.next();
-        });
+            throw err;
+        }
+    }
+
+    static async monitorStack(context) {
+        try {
+            await Actions.monitor(context.stackName, context.stackRegion);
+        } catch (err) {
+            err.failure = err.message;
+            err.message = `Monitoring your deploy failed, but the deploy in region ${context.stackRegion} will continue. Check on your stack's status in the CloudFormation console.`;
+            throw err;
+        }
+
+        return;
     },
 
-    monitorStack: function(context) {
-        actions.monitor(context.stackName, context.stackRegion, function(err) {
-            if (err) {
-                err.failure = err.message;
-                err.message = `Monitoring your deploy failed, but the deploy in region ${context.stackRegion} will continue. Check on your stack's status in the CloudFormation console.`;
-                return context.abort(err);
-            }
+    static async getOldParameters(context) {
+        try {
+            await Lookup.parameters(context.stackName, context.stackRegion);
+        } catch (err) {
+            let msg = '';
+            if (err instanceof lookup.StackNotFoundError) msg += 'Missing stack: ';
+            if (err instanceof lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
+            msg += err.message;
+            err.message = msg;
+            throw err;
+        }
 
-            context.next();
-        });
-    },
+        context.oldParameters = info;
 
-    getOldParameters: function(context) {
-        lookup.parameters(context.stackName, context.stackRegion, function(err, info) {
-            if (err) {
-                var msg = '';
-                if (err instanceof lookup.StackNotFoundError) msg += 'Missing stack: ';
-                if (err instanceof lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
+        return;
+    }
 
-            context.oldParameters = info;
-            context.next();
-        });
-    },
-
-    promptSaveConfig: async function(context) {
+    static async promptSaveConfig(context) {
         const name = await Prompt.input('Name for saved configuration:', context.suffix);
         context.saveName = name;
-        context.next();
-    },
 
-    confirmSaveConfig: async function(context) {
+        return;
+    }
+
+    static async confirmSaveConfig(context) {
         process.stdout.write(stableStringify(context.oldParameters, { space: 2 }) + '\n\n');
         const ready = await Prompt.confirm('Ready to save this configuration as "' + context.saveName + '"?');
-        if (!ready) return context.abort();
-        context.next();
+        if (!ready) throw new Error();
+
+        return;
     },
 
-    saveConfig: async function(context) {
+    static async saveConfig(context) {
         const kms = (context.overrides.kms && typeof context.overrides.kms !== 'string') ? 'alias/cloudformation' : context.overrides.kms;
         const maskedParameters = Object.assign({}, context.newParameters || {});
         const templateBody = context.newTemplate || {};
@@ -685,23 +691,24 @@ const operations = module.exports.operations = {
             if (err instanceof actions.S3Error) msg += 'Failed to save template: ';
             msg += err.message;
             err.message = msg;
-            return context.abort(err);
+            throw err;
         }
 
-        context.next();
+        return;
     },
 
-    mergeMetadata: function(context) {
-        if (!context.overrides.metadata) return context.next();
+    static async mergeMetadata(context) {
+        if (!context.overrides.metadata) return;
         context.newTemplate.Metadata = context.newTemplate.Metadata || {};
         for (var k in context.overrides.metadata) {
             if (context.newTemplate.Metadata[k] !== undefined) {
-                return context.next(new Error('Metadata.' + k + ' already exists in template'));
+                throw new Error('Metadata.' + k + ' already exists in template');
             } else {
                 context.newTemplate.Metadata[k] = context.overrides.metadata[k];
             }
         }
-        context.next();
+
+        return;
     }
 };
 
@@ -732,20 +739,21 @@ function compareTemplate(existing, desired) {
         assert.equal(existing, desired);
         return;
     } catch (err) {
-        var strDiff = Diff.diffLines(existing, desired, {
+        const strDiff = Diff.diffLines(existing, desired, {
             ignoreWhitespace: true
         });
-        var diffText = '';
+
+        let diffText = '';
 
         strDiff.forEach(function(part, i){
-            var color = part.added ? 'green' : part.removed ? 'red' : 'grey';
-            var delimiter = '\n---------------------------------------------\n\n';
+            const color = part.added ? 'green' : part.removed ? 'red' : 'grey';
+            const delimiter = '\n---------------------------------------------\n\n';
 
             if (color === 'grey') {
-                var lines = part.value.split('\n').slice(0, -1);
+                const lines = part.value.split('\n').slice(0, -1);
                 if (lines.length > 10) {
-                    var first = lines.slice(0, 3).map((line) => ` ${line}`);
-                    var last = lines.slice(-3).map((line) => ` ${line}`);
+                    const first = lines.slice(0, 3).map((line) => ` ${line}`);
+                    const last = lines.slice(-3).map((line) => ` ${line}`);
                     if (i !== 0) diffText += `${first.join('\n')}\n`.grey;
                     if (i !== 0 && i !== strDiff.length - 1) diffText += delimiter.grey;
                     if (i !== strDiff.length - 1) diffText += `${last.join('\n')}\n`.grey;
@@ -753,7 +761,7 @@ function compareTemplate(existing, desired) {
                 }
             }
 
-            var toPrint = part.value
+            let toPrint = part.value
                 .split('\n')
                 .map((line) => `${!line.length ? '' : part.added ? '+' : part.removed ? '-' : ' '}${line}`)
                 .join('\n')[color];
@@ -766,7 +774,7 @@ function compareTemplate(existing, desired) {
 }
 
 function formatDiff(details) {
-    var t = new Table();
+    const t = new Table();
 
     function colors(msg) {
         if (msg === 'Modify') return msg.yellow;
@@ -813,9 +821,13 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
         const unchanged = oldParameters[key] === newParameters[key];
         const isOverriden = overrideParameters[key] && unchanged;
 
-        if (isCreate || isOverriden) parameter.ParameterValue = value;
-        else if (unchanged) parameter.UsePreviousValue = true;
-        else parameter.ParameterValue = value;
+        if (isCreate || isOverriden) {
+            parameter.ParameterValue = value;
+        } else if (unchanged) {
+            parameter.UsePreviousValue = true;
+        } else {
+            parameter.ParameterValue = value;
+        }
 
         return parameter;
     });

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -54,10 +54,13 @@ require('colors');
  * @param {string} config.configBucket - the bucket that contains saved configurations
  * @param {string} config.templateBucket - the bucket where templates can be stored.
  * This bucket must be in the same region as the stack.
+ *
+ * @param {boolean} dryrun Used by the tests to return the context without running
  */
 class Commands {
-    constructor(config) {
+    constructor(config, dryrun=false) {
         this.config = config;
+        this.dryrun = dryrun;
     }
 
     /**
@@ -91,6 +94,7 @@ class Commands {
         context.overrides = overrides;
         context.template = template;
 
+        if (this.dryrun) return context;
         await context.run();
     }
 
@@ -129,6 +133,7 @@ class Commands {
         context.overrides = overrides;
         context.template = template;
 
+        if (this.dryrun) return context;
         await context.run();
     }
 
@@ -149,6 +154,7 @@ class Commands {
 
         context.overrides = overrides;
 
+        if (this.dryrun) return context;
         await context.run();
     }
 
@@ -161,7 +167,8 @@ class Commands {
      * @param {boolean} [decrypt=false] - return secure parameters decrypted
      */
     async info(suffix, resources=false, decrypt=false) {
-        await Lookup.info(stackName(config.name, suffix), config.region, resources, decrypt);
+        if (this.dryrun) return true;
+        return await Lookup.info(stackName(this.config.name, suffix), this.config.region, resources, decrypt);
     }
 
     /**
@@ -183,6 +190,7 @@ class Commands {
 
         context.kms = kms;
 
+        if (this.dryrun) return context;
         await context.run();
     }
 }
@@ -199,6 +207,7 @@ class Commands {
  */
 class CommandContext {
     constructor(config, suffix, operations)  {
+        this.config = config;
         this.baseName = config.name;
         this.suffix = suffix;
         this.stackName = stackName(config.name, suffix);
@@ -216,8 +225,6 @@ class CommandContext {
         for (const op of this.operations) {
             await operations(this);
         }
-
-        return this.diffs;
     }
 }
 
@@ -257,7 +264,7 @@ class Operations {
                 if (err instanceof lookup.CloudFormationError) msg += 'Failed to find existing stack: ';
                 msg += err.message;
                 err.message = msg;
-                return context.abort(err);
+                throw err;
             }
 
             context.newTemplate = templateBody;
@@ -266,14 +273,14 @@ class Operations {
 
             return;
         });
-    },
+    }
 
     static async getMasterConfig(context) {
         if (!context.overrides.masterConfig) return;
         var s3Url = context.overrides.masterConfig;
 
         const masterConfigJSON = await Lookup.defaultConfiguration(s3Url);
-        Object.keys(masterConfigJSON).forEach((key) => {
+        Object.keys(masterConfigJSON).forEach(async (key) => {
             if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
                 if (context.oldParameters[key].indexOf('secure') > -1) {
                     const kms = new AWS.KMS({
@@ -296,7 +303,7 @@ class Operations {
         });
 
         return;
-    },
+    }
 
     static async promptParameters(context) {
         const newTemplateParameters = context.newTemplate.Parameters || {};
@@ -323,7 +330,7 @@ class Operations {
                 overrideParameters,
                 context.create
             );
-            return context.next();
+            return;
         }
         else {
             Object.assign(context.oldParameters, overrideParameters);
@@ -346,18 +353,18 @@ class Operations {
         );
 
         return;
-    },
+    }
 
     static async confirmParameters(context) {
         if (context.overrides.force || context.overrides.skipConfirmParameters) {
-            return context.next();
+            return;
         }
 
         const diff = compare(context.oldParameters, context.newParameters);
 
         if (!diff) {
             context.overrides.skipConfirmParameters = true;
-            return context.next();
+            return;
         }
 
         if (context.overrides.preapproved && context.overrides.preapproved.parameters) {
@@ -368,26 +375,27 @@ class Operations {
             if (preapproved) {
                 console.log('Auto-confirming parameter changes... Changes were pre-approved in another region.');
                 context.overrides.skipConfirmParameters = true;
-                return context.next();
+                return;
             }
         }
 
         const ready = await Prompt.confirm([diff, 'Accept parameter changes?'].join('\n'));
-        if (!ready) return context.abort();
+        if (!ready) throw new Error();
         context.diffs.parameters = diff;
-        context.next();
-    },
+
+        return;
+    }
 
     static async confirmTemplate(context) {
         if (context.overrides.force || context.overrides.skipConfirmTemplate) {
-            return context.next();
+            return;
         }
 
         const diff = compareTemplate(context.oldTemplate, context.newTemplate);
 
         if (!diff) {
             context.overrides.skipConfirmTemplate = true;
-            return context.next();
+            return;
         }
 
         if (context.overrides.preapproved && context.overrides.preapproved.template) {
@@ -398,15 +406,16 @@ class Operations {
             if (preapproved) {
                 console.log('Auto-confirming template changes... Changes were pre-approved in another region.');
                 context.overrides.skipConfirmTemplate = true;
-                return context.next();
+                return;
             }
         }
 
         const ready = await Prompt.confirm([diff, 'Accept template changes?'].join('\n'));
-        if (!ready) return context.abort();
+        if (!ready) throw new Error();
         context.diffs.template = diff;
-        context.next();
-    },
+
+        return;
+    }
 
     static async saveTemplate(context) {
         context.templateUrl = Actions.templateUrl(context.templateBucket, context.stackRegion, context.suffix);
@@ -439,22 +448,22 @@ class Operations {
     }
 
     static async validateParametersHook(context) {
-        if (!context.overrides.validateParameters) return context.next();
+        if (!context.overrides.validateParameters) return;
 
         context.overrides.validateParameters(context, function(err) {
-            if (err) return context.abort(err);
-            context.next();
+            if (err) throw err;
+            return;
         });
-    },
+    }
 
     static async beforeUpdateHook(context) {
-        if (!context.overrides.beforeUpdate) return context.next();
+        if (!context.overrides.beforeUpdate) return;
 
         context.overrides.beforeUpdate(context, function(err) {
-            if (err) return context.abort(err);
-            context.next();
+            if (err) throw err;
+            return;
         });
-    },
+    }
 
     static async getChangesetCreate(context) {
         operations.getChangeset(context, 'CREATE');
@@ -484,11 +493,11 @@ class Operations {
         context.changeset = details;
 
         return;
-    },
+    }
 
     static async confirmChangeset(context) {
         if (context.overrides.force || (context.overrides.skipConfirmTemplate && context.overrides.skipConfirmParameters)) {
-            return context.next();
+            return;
         }
 
         var msg = [
@@ -497,9 +506,10 @@ class Operations {
         ].join('\n');
 
         const ready = await Prompt.confirm(msg, false);
-        if (!ready) return context.abort();
-        context.next();
-    },
+        if (!ready) throw new Error();
+
+        return;
+    }
 
     static async executeChangeSet(context) {
         try {
@@ -514,7 +524,7 @@ class Operations {
         }
 
         return;
-    },
+    }
 
     static async createPreamble(context) {
         var preamble = d3.queue();
@@ -543,14 +553,15 @@ class Operations {
                 if (err instanceof lookup.S3Error) msg += 'Could not load saved configurations: ';
                 msg += err.message;
                 err.message = msg;
-                return context.abort(err);
+                throw err;
             }
 
             context.newTemplate = templateBody;
             context.configNames = configs;
-            context.next();
+
+            return;
         });
-    },
+    }
 
     static async selectConfig(context) {
         if (context.overrides.force) return;
@@ -561,7 +572,7 @@ class Operations {
         context.configName = savedConfig;
 
         return;
-    },
+    }
 
     static async loadConfig(context) {
         function finished(err, info) {
@@ -573,20 +584,23 @@ class Operations {
                 if (err instanceof lookup.S3Error) msg += 'Failed to read saved configuration: ';
                 msg += err.message;
                 err.message = msg;
-                return context.abort(err);
+                throw err;
             }
 
             context.oldParameters = info;
-            context.next();
+            return;
         }
 
         if (!context.configName) {
-            if (context.overrides.defaultConfig) return lookup.defaultConfiguration(context.overrides.defaultConfig, finished);
-            else return context.next();
+            if (context.overrides.defaultConfig) {
+                return lookup.defaultConfiguration(context.overrides.defaultConfig, finished);
+            } else {
+                return;
+            }
         }
 
         lookup.configuration(context.baseName, context.configBucket, context.configName, finished);
-    },
+    }
 
     static async confirmCreate(context) {
         if (context.overrides.force) return;
@@ -595,16 +609,16 @@ class Operations {
         if (!ready) throw new Error();
 
         return;
-    },
+    }
 
     static async confirmDelete(context) {
-        if (context.overrides.force) return context.next();
+        if (context.overrides.force) return;
         const msg = 'Are you sure you want to delete ' + context.stackName + ' in region ' + context.stackRegion + '?';
         const ready = await Prompt.confirm(msg, false);
         if (!ready) throw new Error();
 
         return;
-    },
+    }
 
     static async deleteStack(context) {
         try {
@@ -628,7 +642,7 @@ class Operations {
         }
 
         return;
-    },
+    }
 
     static async getOldParameters(context) {
         try {
@@ -660,7 +674,7 @@ class Operations {
         if (!ready) throw new Error();
 
         return;
-    },
+    }
 
     static async saveConfig(context) {
         const kms = (context.overrides.kms && typeof context.overrides.kms !== 'string') ? 'alias/cloudformation' : context.overrides.kms;
@@ -693,7 +707,7 @@ class Operations {
         }
 
         return;
-    },
+    }
 
     static async mergeMetadata(context) {
         if (!context.overrides.metadata) return;
@@ -831,4 +845,8 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
     });
 }
 
-module.exports = Commands;
+module.exports = {
+    Commands,
+    CommandContext,
+    Operations
+}

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -6,7 +6,7 @@ const stableStringify = require('json-stable-stringify');
 const Diff = require('diff');
 const Table = require('easy-table');
 const actions = require('./actions');
-const lookup = require('./lookup');
+const Lookup = require('./lookup');
 const Prompt = require('./prompt');
 const Template = require('./template');
 const d3 = require('d3-queue');
@@ -180,18 +180,9 @@ module.exports = function(config) {
      * @param {boolean} [resources=false] - if set to `true`, returned information
      * will include details of each resource in the stack
      * @param {boolean} [decrypt=false] - return secure parameters decrypted
-     * @param {function} callback - a function fired with the stack's information
      */
-    commands.info = function(suffix, resources, decrypt, callback) {
-        if (typeof resources === 'function') {
-            callback = resources;
-            resources = false;
-        } else if (typeof decrypt === 'function') {
-            callback = decrypt;
-            decrypt = false;
-        }
-
-        lookup.info(stackName(config.name, suffix), config.region, resources, decrypt, callback);
+    commands.info = async function(suffix, resources=false, decrypt=false) {
+        await lookup.info(stackName(config.name, suffix), config.region, resources, decrypt);
     };
 
     /**
@@ -700,20 +691,7 @@ const operations = module.exports.operations = {
         context.next();
     },
 
-    saveConfig: function(context) {
-        function finished(err) {
-            if (err) {
-                var msg = '';
-                if (err instanceof actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
-                if (err instanceof actions.S3Error) msg += 'Failed to save template: ';
-                msg += err.message;
-                err.message = msg;
-                return context.abort(err);
-            }
-
-            context.next();
-        }
-
+    saveConfig: async function(context) {
         const kms = (context.overrides.kms && typeof context.overrides.kms !== 'string') ? 'alias/cloudformation' : context.overrides.kms;
         const maskedParameters = Object.assign({}, context.newParameters || {});
         const templateBody = context.newTemplate || {};
@@ -725,15 +703,25 @@ const operations = module.exports.operations = {
         });
 
 
-        actions.saveConfiguration(
-            context.baseName,
-            context.stackName,
-            context.stackRegion,
-            context.configBucket,
-            maskedParameters,
-            kms,
-            finished
-        );
+        try {
+            await actions.saveConfiguration(
+                context.baseName,
+                context.stackName,
+                context.stackRegion,
+                context.configBucket,
+                maskedParameters,
+                kms
+            );
+        } catch (err) {
+            let msg = '';
+            if (err instanceof actions.BucketNotFoundError) msg += 'Could not find template bucket: ';
+            if (err instanceof actions.S3Error) msg += 'Failed to save template: ';
+            msg += err.message;
+            err.message = msg;
+            return context.abort(err);
+        }
+
+        context.next();
     },
 
     mergeMetadata: function(context) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -276,7 +276,7 @@ class Operations {
 
         const masterConfigJSON = await Lookup.defaultConfiguration(context.overrides.masterConfig);
         Object.keys(masterConfigJSON).forEach(async(key) => {
-            if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
+            if (Object.prototype.hasOwnProperty(context.oldParameters, key)) {
 
                 if (context.oldParameters[key].includes('secure')) {
                     const kms = new AWS.KMS({
@@ -559,6 +559,8 @@ class Operations {
                 try {
                     const info = await Lookup.defaultConfiguration(context.overrides.defaultConfig);
                     context.oldParameters = info;
+
+                    return;
                 } catch (err){
                     let msg = '';
                     if (err instanceof Lookup.BucketNotFoundError) msg += 'Could not find config bucket: ';
@@ -684,8 +686,9 @@ class Operations {
 
     static async mergeMetadata(context) {
         if (!context.overrides.metadata) return;
+
         context.newTemplate.Metadata = context.newTemplate.Metadata || {};
-        for (var k in context.overrides.metadata) {
+        for (const k in context.overrides.metadata) {
             if (context.newTemplate.Metadata[k] !== undefined) {
                 throw new Error('Metadata.' + k + ' already exists in template');
             } else {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -221,9 +221,16 @@ class CommandContext {
     }
 
     async run() {
-        for (const op of this.operations) {
-            await op(this);
+        try {
+            for (const op of this.operations) {
+                await op(this);
+            }
+        } catch (err) {
+            if (err.message === 'aborted') return false;
+            throw err;
         }
+
+        return true;
     }
 }
 
@@ -278,10 +285,10 @@ class Operations {
 
                     const valueToDecrypt = context.oldParameters[key].replace(/^secure:/, '');
                     const data = await kms.decrypt({
-                        CiphertextBlob: new Buffer(valueToDecrypt, 'base64')
+                        CiphertextBlob: new Buffer.from(valueToDecrypt, 'base64')
                     }).promise();
 
-                    const decryptedOldParams = new Buffer(data.Plaintext, 'base64').toString('utf-8');
+                    const decryptedOldParams = new Buffer.from(data.Plaintext, 'base64').toString('utf-8');
                     const decryptedMaster = masterConfigJSON[key];
                     if (decryptedOldParams !== decryptedMaster) {
                         context.oldParameters[key] = masterConfigJSON[key];
@@ -368,7 +375,7 @@ class Operations {
         }
 
         const ready = await Prompt.confirm([diff, 'Accept parameter changes?'].join('\n'));
-        if (!ready) throw new Error();
+        if (!ready) throw new Error('aborted');
         context.diffs.parameters = diff;
 
         return;
@@ -399,7 +406,7 @@ class Operations {
         }
 
         const ready = await Prompt.confirm([diff, 'Accept template changes?'].join('\n'));
-        if (!ready) throw new Error();
+        if (!ready) throw new Error('aborted');
         context.diffs.template = diff;
 
         return;
@@ -454,11 +461,11 @@ class Operations {
     }
 
     static async getChangesetCreate(context) {
-        operations.getChangeset(context, 'CREATE');
+        await Operations.getChangeset(context, 'CREATE');
     }
 
     static async getChangesetUpdate(context) {
-        operations.getChangeset(context, 'UPDATE');
+        await Operations.getChangeset(context, 'UPDATE');
     }
 
     static async getChangeset(context, changeSetType) {
@@ -471,16 +478,14 @@ class Operations {
                 context.changesetParameters,
                 context.overrides.expand,
             );
+
+            context.changeset = details;
         } catch (err) {
             let msg = 'Failed to generate changeset: '; // err instanceof Actions.CloudFormationError
             msg += err.message;
             err.message = msg;
             throw err;
         }
-
-        context.changeset = details;
-
-        return;
     }
 
     static async confirmChangeset(context) {
@@ -494,9 +499,7 @@ class Operations {
         ].join('\n');
 
         const ready = await Prompt.confirm(msg, false);
-        if (!ready) throw new Error();
-
-        return;
+        if (!ready) throw new Error('aborted');
     }
 
     static async executeChangeSet(context) {
@@ -510,8 +513,6 @@ class Operations {
             err.message = msg;
             throw err;
         }
-
-        return;
     }
 
     static async createPreamble(context) {
@@ -591,18 +592,14 @@ class Operations {
         if (context.overrides.force) return;
 
         const ready = await Prompt.confirm('Ready to create the stack?');
-        if (!ready) throw new Error();
-
-        return;
+        if (!ready) throw new Error('aborted');
     }
 
     static async confirmDelete(context) {
         if (context.overrides.force) return;
         const msg = 'Are you sure you want to delete ' + context.stackName + ' in region ' + context.stackRegion + '?';
         const ready = await Prompt.confirm(msg, false);
-        if (!ready) throw new Error();
-
-        return;
+        if (!ready) throw new Error('aborted');
     }
 
     static async deleteStack(context) {
@@ -625,8 +622,6 @@ class Operations {
             err.message = `Monitoring your deploy failed, but the deploy in region ${context.stackRegion} will continue. Check on your stack's status in the CloudFormation console.`;
             throw err;
         }
-
-        return;
     }
 
     static async getOldParameters(context) {
@@ -651,7 +646,7 @@ class Operations {
     static async confirmSaveConfig(context) {
         process.stdout.write(stableStringify(context.oldParameters, { space: 2 }) + '\n\n');
         const ready = await Prompt.confirm('Ready to save this configuration as "' + context.saveName + '"?');
-        if (!ready) throw new Error();
+        if (!ready) throw new Error('aborted');
     }
 
     static async saveConfig(context) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -276,8 +276,7 @@ class Operations {
 
         const masterConfigJSON = await Lookup.defaultConfiguration(context.overrides.masterConfig);
         Object.keys(masterConfigJSON).forEach(async(key) => {
-            if (Object.prototype.hasOwnProperty(context.oldParameters, key)) {
-
+            if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
                 if (context.oldParameters[key].includes('secure')) {
                     const kms = new AWS.KMS({
                         region: context.stackRegion,

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -277,7 +277,8 @@ class Operations {
         const masterConfigJSON = await Lookup.defaultConfiguration(context.overrides.masterConfig);
         Object.keys(masterConfigJSON).forEach(async(key) => {
             if (Object.prototype.hasOwnProperty.call(context.oldParameters, key)) {
-                if (context.oldParameters[key].indexOf('secure') > -1) {
+
+                if (context.oldParameters[key].includes('secure')) {
                     const kms = new AWS.KMS({
                         region: context.stackRegion,
                         maxRetries: 10

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -2,7 +2,6 @@ const AWS = require('aws-sdk');
 const error = require('fasterror');
 const path = require('path');
 const s3urls = require('s3urls');
-const queue = require('d3-queue').queue;
 
 /**
  * Information about a CloudFormation stack
@@ -20,14 +19,10 @@ class Lookup {
      *
      * @param {string} name - the full name of the stack
      * @param {string} region - the region the stack is in
-     * @param {function} callback - a function that will be provided a {@link StackInfo}
-     * or an error if one was encountered
      */
-    static parameters(name, region, callback) {
-        Lookup.info(name, region, function(err, info) {
-            if (err) return callback(err);
-            callback(null, info.Parameters);
-        });
+    static async parameters(name, region) {
+        const info = await Lookup.info(name, region);
+        return info.Parameters;
     }
 
     /**
@@ -37,81 +32,77 @@ class Lookup {
      * @param {string} region - the region the stack is in
      * @param {boolean} [resources=false] - return information about each resource in the stack
      * @param {boolean} [decrypt=false] - return secure parameters decrypted
-     * @param {function} callback - a function that will be provided a {@link StackInfo}
-     * or an error if one was encountered
      */
-    static info(name, region, resources, decrypt, callback) {
-        if (typeof resources === 'function') {
-            callback = resources;
-            resources = false;
-            decrypt = false;
-        } else if (typeof decrypt === 'function') {
-            callback = decrypt;
-            decrypt = false;
-        }
-
-        const cfn = new AWS.CloudFormation({ region: region });
-
-        cfn.describeStacks({
-            StackName: name
-        }, (err, data) => {
-            if (err && err.code === 'ValidationError' && /Stack with id/.test(err.message))
-                return callback(new Lookup.StackNotFoundError('Stack %s not found in %s', name, region));
-            if (err) return callback(new Lookup.CloudFormationError('%s: %s', err.code, err.message));
-            if (!data.Stacks.length) return callback(new Lookup.StackNotFoundError('Stack %s not found in %s', name, region));
-
-            const stackInfo = data.Stacks[0];
-            stackInfo.Region = region;
-
-            stackInfo.Parameters = (stackInfo.Parameters || []).reduce((memo, param) => {
-                memo[param.ParameterKey] = param.ParameterValue;
-                return memo;
-            }, {});
-
-            stackInfo.Outputs = (stackInfo.Outputs || []).reduce((memo, output) => {
-                memo[output.OutputKey] = output.OutputValue;
-                return memo;
-            }, {});
-
-            stackInfo.Tags = (stackInfo.Tags || []).reduce((memo, output) => {
-                memo[output.Key] = output.Value;
-                return memo;
-            }, {});
-
-            getResources(stackInfo);
+    static async info(name, region, resources=false, decrypt=false) {
+        const cfn = new AWS.CloudFormation({
+            region: region
         });
 
-        function getResources(stackInfo) {
-            if (!resources) return getDecrypted(stackInfo);
-
-            const data = {
-                StackResourceSummaries: []
-            };
-
-            cfn.listStackResources({
+        let data;
+        try {
+            data = await cfn.describeStacks({
                 StackName: name
-            }).eachPage((err, page, done) => {
-                if (err) return callback(new Lookup.CloudFormationError('%s: %s', err.code, err.message));
-                if (!page) {
-                    // all pages received, continue
-                    stackInfo.StackResources = data.StackResourceSummaries;
-                    return getDecrypted(stackInfo);
-                }
-
-                // collect data and wait for next page
-                data.StackResourceSummaries = data.StackResourceSummaries.concat(page.StackResourceSummaries);
-                done();
-            });
+            }).promise();
+        } catch (err) {
+            if (err.code === 'ValidationError' && /Stack with id/.test(err.message)) {
+                throw new Lookup.StackNotFoundError('Stack %s not found in %s', name, region);
+            } else {
+                throw new Lookup.CloudFormationError('%s: %s', err.code, err.message);
+            }
         }
 
-        function getDecrypted(stackInfo) {
-            if (!decrypt) return callback(null, stackInfo);
+        if (!data.Stacks.length) throw new Lookup.StackNotFoundError('Stack %s not found in %s', name, region);
 
-            Lookup.decryptParameters(stackInfo.Parameters, region, (err, decryptedParameters) => {
-                if (err) return callback(err);
-                stackInfo.Parameters = decryptedParameters;
-                callback(null, stackInfo);
-            });
+        const stackInfo = data.Stacks[0];
+        stackInfo.Region = region;
+
+        stackInfo.Parameters = (stackInfo.Parameters || []).reduce((memo, param) => {
+            memo[param.ParameterKey] = param.ParameterValue;
+            return memo;
+        }, {});
+
+        stackInfo.Outputs = (stackInfo.Outputs || []).reduce((memo, output) => {
+            memo[output.OutputKey] = output.OutputValue;
+            return memo;
+        }, {});
+
+        stackInfo.Tags = (stackInfo.Tags || []).reduce((memo, output) => {
+            memo[output.Key] = output.Value;
+            return memo;
+        }, {});
+
+        if (!resources) {
+            if (!decrypt) return stackInfo;
+            stackInfo.Parameters = await Lookup.decryptParameters(stackInfo.Parameters, region);
+            return stackInfo;
+        }
+
+        const resource_data = {
+            StackResourceSummaries: []
+        };
+
+        try {
+            let page = await cfn.listStackResources({
+                StackName: name
+            }).promise();
+
+            resource_data.StackResourceSummaries = resource_data.StackResourceSummaries.concat(page.StackResourceSummaries);
+
+            while (page.NextToken) {
+                page = await cfn.listStackResources({
+                    NextToken: page.NextToken
+                }).promise();
+
+                resource_data.StackResourceSummaries = resource_data.StackResourceSummaries.concat(page.StackResourceSummaries);
+            }
+
+            stackInfo.StackResources = resource_data.StackResourceSummaries;
+
+            if (!decrypt) return stackInfo;
+            stackInfo.Parameters = await Lookup.decryptParameters(stackInfo.Parameters, region);
+            return stackInfo;
+        } catch (err) {
+            throw new Lookup.CloudFormationError('%s: %s', err.code, err.message);
         }
     }
 
@@ -120,22 +111,26 @@ class Lookup {
      *
      * @param {string} name - the full name of the stack
      * @param {string} region - the region the stack is in
-     * @param {function} callback - a function that will be provided the template body
-     * as a parsed JS object, or an error if one was encountered
      */
-    static template(name, region, callback) {
-        const cfn = new AWS.CloudFormation({ region: region });
-
-        cfn.getTemplate({
-            StackName: name,
-            TemplateStage: 'Original'
-        }, (err, data) => {
-            if (err && err.code === 'ValidationError' && /Stack with id/.test(err.message))
-                return callback(new Lookup.StackNotFoundError('Stack %s not found in %s', name, region));
-            if (err) return callback(new Lookup.CloudFormationError('%s: %s', err.code, err.message));
-
-            callback(null, JSON.parse(data.TemplateBody));
+    static async template(name, region) {
+        const cfn = new AWS.CloudFormation({
+            region: region
         });
+
+        try {
+            const data = await cfn.getTemplate({
+                StackName: name,
+                TemplateStage: 'Original'
+            }).promise();
+
+            return JSON.parse(data.TemplateBody);
+        } catch (err) {
+            if (err.code === 'ValidationError' && /Stack with id/.test(err.message)) {
+                throw new Lookup.StackNotFoundError('Stack %s not found in %s', name, region);
+            } else {
+                throw new Lookup.CloudFormationError('%s: %s', err.code, err.message);
+            }
+        }
     }
 
     /**
@@ -144,38 +139,30 @@ class Lookup {
      * @param {string} name - the base name of the stack (no suffix)
      * @param {string} bucket - the name of the S3 bucket containing saved configurations
      * @param {string} [region] - the name of the region in which to make lookup requests
-     * @param {function} callback - a function that will be provided with a list of
-     * saved configuration names
-     * @returns
      */
-    static configurations(name, bucket, region, callback) {
-        if (typeof region === 'function') {
-            callback = region;
-            region = undefined;
-        }
+    static async configurations(name, bucket, region) {
+        region = await Lookup.bucketRegion(bucket, region);
 
-        Lookup.bucketRegion(bucket, region, (err, region) => {
-            if (err) return callback(err);
+        const s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
 
-            const s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
-
-            s3.listObjects({
+        try {
+            const data = await s3.listObjects({
                 Bucket: bucket,
                 Prefix: name + '/'
-            }, function(err, data) {
-                if (err && err.code === 'NoSuchBucket')
-                    return callback(new Lookup.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region));
-                if (err) return callback(new Lookup.S3Error('%s: %s', err.code, err.message));
+            }).promise();
 
-                const keys = data.Contents.filter((obj) => {
-                    return obj.Key.split('.').slice(-2).join('.') === 'cfn.json' && obj.Size > 0;
-                }).map((obj) => {
-                    return path.basename(obj.Key, '.cfn.json');
-                });
-
-                callback(null, keys);
+            return data.Contents.filter((obj) => {
+                return obj.Key.split('.').slice(-2).join('.') === 'cfn.json' && obj.Size > 0;
+            }).map((obj) => {
+                return path.basename(obj.Key, '.cfn.json');
             });
-        });
+        } catch (err) {
+            if (err.code === 'NoSuchBucket') {
+                throw new Lookup.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region);
+            } else {
+                throw new Lookup.S3Error('%s: %s', err.code, err.message);
+            }
+        }
     }
 
     /**
@@ -184,32 +171,39 @@ class Lookup {
      * @param {string} name - the base name of the stack (no suffix)
      * @param {string} bucket - the name of the S3 bucket containing saved configurations
      * @param {string} config - the name of the saved configuration
-     * @param {function} callback - a function that will be provided with the saved configuration
      */
-    static configuration(name, bucket, config, callback) {
-        Lookup.bucketRegion(bucket, function(err, region) {
-            if (err) return callback(err);
+    static async configuration(name, bucket, config) {
+        const region = await Lookup.bucketRegion(bucket);
 
-            var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
+        const s3 = new AWS.S3({
+            region: region,
+            signatureVersion: 'v4'
+        });
 
-            s3.getObject({
+        let data;
+        try {
+            data = await s3.getObject({
                 Bucket: bucket,
                 Key: Lookup.configKey(name, config)
-            }, function(err, data) {
-                if (err && err.code === 'NoSuchBucket')
-                    return callback(new Lookup.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region));
-                if (err && err.code === 'NoSuchKey')
-                    return callback(new Lookup.ConfigurationNotFoundError('Configuration %s not found in %s in %s', config, bucket, region));
-                if (err)
-                    return callback(new Lookup.S3Error('%s: %s', err.code, err.message));
+            }).promise();
+        } catch (err) {
+            if (err.code === 'NoSuchBucket') {
+                throw new Lookup.BucketNotFoundError('S3 bucket %s not found in %s', bucket, region);
+            } else if (err.code === 'NoSuchKey') {
+                throw new Lookup.ConfigurationNotFoundError('Configuration %s not found in %s in %s', config, bucket, region);
+            } else {
+                throw new Lookup.S3Error('%s: %s', err.code, err.message);
+            }
+        }
 
-                var info = data.Body.toString();
-                try { info = JSON.parse(info); }
-                catch (err) { return callback(new Lookup.InvalidConfigurationError('Invalid configuration')); }
+        let info = data.Body.toString();
+        try {
+            info = JSON.parse(info);
+        } catch (err) {
+            throw new Lookup.InvalidConfigurationError('Invalid configuration');
+        }
 
-                callback(null, info);
-            });
-        });
+        return info;
     }
 
     /**
@@ -217,26 +211,38 @@ class Lookup {
      * silently absorb any failures encountered while fetching or parsing the requested file.
      *
      * @param {string} s3url - a URL pointing to a configuration object on S3
-     * @param {function} callback - a function which will be provided with the saved configuration
      *
      */
-    static defaultConfiguration(s3url, callback) {
-        var params = s3urls.fromUrl(s3url);
-        Lookup.bucketRegion(params.Bucket, function(err, region) {
-            if (err) return callback(null, {});
+    static async defaultConfiguration(s3url) {
+        const params = s3urls.fromUrl(s3url);
 
-            var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
+        let region;
+        try {
+            region = await Lookup.bucketRegion(params.bucket);
+        } catch (err) {
+            return {};
+        }
 
-            s3.getObject(params, function(err, data) {
-                if (err) return callback(null, {});
-
-                var info = data.Body.toString();
-                try { info = JSON.parse(info); }
-                catch (err) { return callback(null, {}); }
-
-                callback(null, info);
-            });
+        const s3 = new AWS.S3({
+            region: region,
+            signatureVersion: 'v4'
         });
+
+        let data;
+        try {
+            data = await s3.getObject(params).promise();
+        } catch (err) {
+            return {};
+        }
+
+        let info = data.Body.toString();
+        try {
+            info = JSON.parse(info);
+        } catch (err) {
+            return {};
+        }
+
+        return info;
     }
 
     /**
@@ -258,22 +264,26 @@ class Lookup {
      *
      * @param {string} bucket - the name of the bucket
      * @param {string} [region] - the name of the region in which to make lookup requests
-     * @param {function} callback - a function provided with the bucket's region
      */
-    static bucketRegion(bucket, region, callback) {
-        if (typeof region === 'function') {
-            callback = region;
-            region = undefined;
-        }
-
-        var s3 = new AWS.S3({ signatureVersion: 'v4', region: region });
-        s3.getBucketLocation({ Bucket: bucket }, function(err, data) {
-            if (err && err.code === 'NoSuchBucket')
-                return callback(new Lookup.BucketNotFoundError('S3 bucket %s not found', bucket));
-            if (err)
-                return callback(new Lookup.S3Error('%s: %s', err.code, err.message));
-            callback(null, data.LocationConstraint || undefined);
+    static async bucketRegion(bucket, region) {
+        const s3 = new AWS.S3({
+            signatureVersion: 'v4',
+            region: region
         });
+
+        try {
+            const data = await s3.getBucketLocation({
+                Bucket: bucket
+            }).promise();
+
+            return data.LocationConstraint || undefined;
+        } catch (err) {
+            if (err.code === 'NoSuchBucket') {
+                throw new Lookup.BucketNotFoundError('S3 bucket %s not found', bucket);
+            } else {
+                throw new Lookup.S3Error('%s: %s', err.code, err.message);
+            }
+        }
     }
 
     /**
@@ -281,30 +291,40 @@ class Lookup {
      *
      * @param {object} parameters - stack parameters
      * @param {string} region - stack region
-     * @param {function} callback - a function provided with the bucket's region
      */
-    static decryptParameters(parameters, region, callback) {
-        var kms = new AWS.KMS({ region: region, maxRetries: 10 });
-        var q = queue();
-        var decrypted = JSON.parse(JSON.stringify(parameters));
-
-        Object.keys(parameters).forEach(function(key) {
-            if (!(/^secure:/).test(parameters[key])) return;
-            q.defer(function(key, val, done) {
-                kms.decrypt({ CiphertextBlob: new Buffer(val, 'base64') }, function(err, data) {
-                    if (err) return done(err);
-                    done(null, { key: key, val: val, decrypted: (new Buffer(data.Plaintext, 'base64')).toString('utf8') });
-                });
-            }, key, parameters[key].replace(/^secure:/, ''));
+    static async decryptParameters(parameters, region) {
+        const kms = new AWS.KMS({
+            region: region,
+            maxRetries: 10
         });
+        const decrypted = JSON.parse(JSON.stringify(parameters));
 
-        q.awaitAll(function(err, results) {
-            if (err) return callback(new Lookup.DecryptParametersError('%s: %s', err.code, err.message));
-            results.forEach(function(data) {
+        try {
+            let results = [];
+            for (const key of Object.keys(parameters)) {
+                if (!(/^secure:/).test(parameters[key])) continue;
+
+                const val = parameters[key].replace(/^secure:/, '');
+
+                const data = await kms.decrypt({
+                    CiphertextBlob: new Buffer.from(val, 'base64')
+                }).promise();
+
+                results.push({
+                    key: key,
+                    val: val,
+                    decrypted: (new Buffer.from(data.Plaintext, 'base64')).toString('utf8')
+                });
+            }
+
+            results.forEach((data) => {
                 decrypted[data.key] = data.decrypted;
             });
-            callback(null, decrypted);
-        });
+
+            return decrypted;
+        } catch (err) {
+            throw new Lookup.DecryptParametersError('%s: %s', err.code, err.message);
+        }
     }
 
     /**

--- a/lib/template.js
+++ b/lib/template.js
@@ -129,7 +129,7 @@ class Template {
                 if ('MaxValue' in parameter) valid = valid && Number(input) <= parameter.MaxValue;
                 if (parameter.AllowedPattern) valid = valid && (new RegExp(parameter.AllowedPattern)).test(input);
                 if (parameter.Type === 'List<Number>') valid = valid && input.split(',').every((num) => {
-                  return !isNaN(parseFloat(num));
+                    return !isNaN(parseFloat(num));
                 });
 
                 return valid;

--- a/lib/template.js
+++ b/lib/template.js
@@ -3,7 +3,6 @@ const path = require('path');
 const error = require('fasterror');
 const AWS = require('aws-sdk');
 const s3urls = require('s3urls');
-const { promisify } = require('util');
 
 /**
  * @class
@@ -47,7 +46,7 @@ class Template {
             }
 
             if (typeof templateBody === 'function') {
-                await promisify(templateBody(options));
+                await async(templateBody, options);
             } else {
                 return templateBody;
             }
@@ -178,6 +177,15 @@ class Template {
      * Error representing an unrecognized KMS failure
      */
     static KmsError = error('KmsError');
+}
+
+function async(fn, config) {
+    return new Promise((resolve, reject) => {
+        fn(config, (err, res) => {
+            if (err) return reject(err);
+            return resolve(res);
+        });
+    });
 }
 
 module.exports = Template;

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,8 +1,9 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 const error = require('fasterror');
 const AWS = require('aws-sdk');
 const s3urls = require('s3urls');
+const { promisify } = require('util');
 
 /**
  * @class
@@ -14,68 +15,73 @@ class Template {
      *
      * @param {string} templatePath - the absolute or relative path to a local file or an S3 url
      * @param {object} [options] - an object to pass as the first argument to async templates
-     * @param {function} callback - a function to receive the template as a JSON object
      */
-    static read(templatePath, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-
+    static async read(templatePath, options={}) {
         const params = s3urls.fromUrl(templatePath);
 
         if (!params.Bucket || !params.Key) {
-            return fs.stat(templatePath, (err) => {
-                if (err) return callback(new Template.NotFoundError('%s does not exist', templatePath));
+            try {
+                await fs.stat(templatePath);
+            } catch (err) {
+                throw new Template.NotFoundError('%s does not exist', templatePath);
+            }
 
-                let templateBody;
+            let templateBody;
 
-                if (!/\.js$/.test(templatePath)) {
-                    templateBody = fs.readFileSync(templatePath);
-                    try { templateBody = JSON.parse(templateBody); }
-                    catch (err) { return callback(new Template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
-                    return callback(null, templateBody);
+            if (!/\.js$/.test(templatePath)) {
+                templateBody = await fs.readFile(templatePath);
+
+                try {
+                    templateBody = JSON.parse(templateBody);
+                } catch (err) {
+                    throw new Template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message);
                 }
 
-                try { templateBody = require(path.resolve(templatePath)); }
-                catch (err) { return callback(new Template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
+                return templateBody;
+            }
 
-                if (typeof templateBody === 'function') templateBody(options, callback);
-                else callback(null, templateBody);
-            });
-        }
+            try {
+                templateBody = require(path.resolve(templatePath));
+            } catch (err) {
+                throw new Template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message);
+            }
 
-        function s3error(err, callback) {
-            callback(new Template.NotFoundError(
-                '%s could not be loaded - S3 responded with %s: %s',
-                templatePath, err.code, err.message
-            ));
+            if (typeof templateBody === 'function') {
+                await promisify(templateBody(options));
+            } else {
+                return templateBody;
+            }
         }
 
         let s3 = new AWS.S3({ signatureVersion: 'v4' });
 
-        s3.getBucketLocation({
-            Bucket: params.Bucket
-        }, (err, data) => {
-            if (err) return s3error(err, callback);
+        let data;
+        try {
+            data = await s3.getBucketLocation({
+                Bucket: params.Bucket
+            }).promise();
+        } catch (err) {
+            throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
+        }
 
-            s3 = new AWS.S3({
-                region: data.LocationConstraint || undefined
-            });
-
-            s3.getObject(params, function(err, data) {
-                if (err) return s3error(err, callback);
-
-                let templateBody;
-                try {
-                    templateBody = JSON.parse(data.Body.toString());
-                } catch (err) {
-                    return callback(new Template.InvalidTemplateError('Failed to parse %s', templatePath));
-                }
-
-                callback(null, templateBody);
-            });
+        s3 = new AWS.S3({
+            region: data.LocationConstraint || undefined
         });
+
+        try {
+            data = s3.getObject(params).promise();
+        } catch (err) {
+            throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
+        }
+
+        let templateBody;
+        try {
+            templateBody = JSON.parse(data.Body.toString());
+        } catch (err) {
+            throw new Template.InvalidTemplateError('Failed to parse %s', templatePath);
+        }
+
+        return templateBody;
     }
 
     /**

--- a/lib/template.js
+++ b/lib/template.js
@@ -17,7 +17,6 @@ class Template {
      */
     static async read(templatePath, options={}) {
         const params = s3urls.fromUrl(templatePath);
-
         if (!params.Bucket || !params.Key) {
             try {
                 await fs.stat(templatePath);
@@ -46,41 +45,41 @@ class Template {
             }
 
             if (typeof templateBody === 'function') {
-                await async(templateBody, options);
+                return await async(templateBody, options);
             } else {
                 return templateBody;
             }
+        } else {
+            let s3 = new AWS.S3({ signatureVersion: 'v4' });
+
+            let data;
+            try {
+                data = await s3.getBucketLocation({
+                    Bucket: params.Bucket
+                }).promise();
+            } catch (err) {
+                throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
+            }
+
+            s3 = new AWS.S3({
+                region: data.LocationConstraint || undefined
+            });
+
+            try {
+                data = s3.getObject(params).promise();
+            } catch (err) {
+                throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
+            }
+
+            let templateBody;
+            try {
+                templateBody = JSON.parse(data.Body.toString());
+            } catch (err) {
+                throw new Template.InvalidTemplateError('Failed to parse %s', templatePath);
+            }
+
+            return templateBody;
         }
-
-        let s3 = new AWS.S3({ signatureVersion: 'v4' });
-
-        let data;
-        try {
-            data = await s3.getBucketLocation({
-                Bucket: params.Bucket
-            }).promise();
-        } catch (err) {
-            throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
-        }
-
-        s3 = new AWS.S3({
-            region: data.LocationConstraint || undefined
-        });
-
-        try {
-            data = s3.getObject(params).promise();
-        } catch (err) {
-            throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
-        }
-
-        let templateBody;
-        try {
-            templateBody = JSON.parse(data.Body.toString());
-        } catch (err) {
-            throw new Template.InvalidTemplateError('Failed to parse %s', templatePath);
-        }
-
-        return templateBody;
     }
 
     /**

--- a/lib/template.js
+++ b/lib/template.js
@@ -66,7 +66,7 @@ class Template {
             });
 
             try {
-                data = s3.getObject(params).promise();
+                data = await s3.getObject(params).promise();
             } catch (err) {
                 throw new Template.NotFoundError('%s could not be loaded - S3 responded with %s: %s', templatePath, err.code, err.message);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -460,9 +460,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-            "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+            "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -678,9 +678,9 @@
             }
         },
         "node_modules/@sinonjs/samsam": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-            "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+            "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.6.0",
@@ -868,9 +868,9 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1063.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz",
-            "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
+            "version": "2.1066.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+            "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -1046,9 +1046,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001302",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
-            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
+            "version": "1.0.30001304",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
+            "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -1432,9 +1432,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.53",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
-            "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
+            "version": "1.4.58",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.58.tgz",
+            "integrity": "sha512-7LXwnKyqcEaMFVXOer+2JPfFs1D+ej7yRRrfZoIH1YlLQZ81OvBNwSCBBLtExVkoMQQgOWwO0FbZVge6U/8rhQ==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1594,9 +1594,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-            "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+            "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.0.5",
@@ -4144,9 +4144,9 @@
             }
         },
         "node_modules/tape": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/tape/-/tape-5.4.1.tgz",
-            "integrity": "sha512-7bGaJ3WnQ/CX3xOWzlR+9lNptEWoD+11gyREP8k+SYrDu2a20EifKpTmZndXn25ZRxesYHSuNtE7Fb+THcjfGA==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-5.5.0.tgz",
+            "integrity": "sha512-hmsc9J+07tM+evk2Rkv7pkbj70Uoy9k0w1yhnN8Sza8kmjhtUTVNltsjywQjC+4grB+EBMKXiJPTkftX8IrbSA==",
             "dev": true,
             "dependencies": {
                 "array.prototype.every": "^1.1.3",
@@ -4907,9 +4907,9 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-            "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+            "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -5097,9 +5097,9 @@
             }
         },
         "@sinonjs/samsam": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-            "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+            "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.6.0",
@@ -5232,9 +5232,9 @@
             "dev": true
         },
         "aws-sdk": {
-            "version": "2.1063.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz",
-            "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
+            "version": "2.1066.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+            "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -5356,9 +5356,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001302",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
-            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
+            "version": "1.0.30001304",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
+            "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
             "dev": true
         },
         "cfn-stack-event-stream": {
@@ -5660,9 +5660,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.53",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
-            "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
+            "version": "1.4.58",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.58.tgz",
+            "integrity": "sha512-7LXwnKyqcEaMFVXOer+2JPfFs1D+ej7yRRrfZoIH1YlLQZ81OvBNwSCBBLtExVkoMQQgOWwO0FbZVge6U/8rhQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -5800,9 +5800,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-            "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+            "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.0.5",
@@ -7715,9 +7715,9 @@
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
         "tape": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/tape/-/tape-5.4.1.tgz",
-            "integrity": "sha512-7bGaJ3WnQ/CX3xOWzlR+9lNptEWoD+11gyREP8k+SYrDu2a20EifKpTmZndXn25ZRxesYHSuNtE7Fb+THcjfGA==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-5.5.0.tgz",
+            "integrity": "sha512-hmsc9J+07tM+evk2Rkv7pkbj70Uoy9k0w1yhnN8Sza8kmjhtUTVNltsjywQjC+4grB+EBMKXiJPTkftX8IrbSA==",
             "dev": true,
             "requires": {
                 "array.prototype.every": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openaddresses/cfn-config",
-    "version": "3.2.1",
+    "version": "4.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@openaddresses/cfn-config",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "aws-sdk": "^2.720.0",
@@ -561,13 +561,15 @@
                 "aws-sdk": "^2.84.0"
             }
         },
-        "node_modules/@mapbox/mock-aws-sdk-js/node_modules/@sinonjs/formatio": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-            "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+        "node_modules/@mapbox/mock-aws-sdk-js/node_modules/@sinonjs/samsam": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+            "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
             "dev": true,
             "dependencies": {
-                "samsam": "1.3.0"
+                "@sinonjs/commons": "^1.3.0",
+                "array-from": "^2.1.1",
+                "lodash": "^4.17.15"
             }
         },
         "node_modules/@mapbox/mock-aws-sdk-js/node_modules/diff": {
@@ -586,6 +588,38 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/@mapbox/mock-aws-sdk-js/node_modules/nise": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+            "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^5.0.1",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
+        "node_modules/@mapbox/mock-aws-sdk-js/node_modules/nise/node_modules/@sinonjs/formatio": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
+            }
+        },
+        "node_modules/@mapbox/mock-aws-sdk-js/node_modules/nise/node_modules/lolex": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0"
             }
         },
         "node_modules/@mapbox/mock-aws-sdk-js/node_modules/sinon": {
@@ -635,24 +669,12 @@
             }
         },
         "node_modules/@sinonjs/formatio": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+            "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^1",
-                "@sinonjs/samsam": "^3.1.0"
-            }
-        },
-        "node_modules/@sinonjs/formatio/node_modules/@sinonjs/samsam": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-            "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^1.3.0",
-                "array-from": "^2.1.1",
-                "lodash": "^4.17.15"
+                "samsam": "1.3.0"
             }
         },
         "node_modules/@sinonjs/samsam": {
@@ -846,9 +868,9 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1062.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-            "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+            "version": "2.1063.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz",
+            "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -1024,9 +1046,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001301",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -1410,9 +1432,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.52",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.52.tgz",
-            "integrity": "sha512-JGkh8HEh5PnVrhU4HbpyyO0O791dVY6k7AdqfDeqbcRMeoGxtNHWT77deR2nhvbLe4dKpxjlDEvdEwrvRLGu2Q==",
+            "version": "1.4.53",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
+            "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1885,9 +1907,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-            "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
         },
         "node_modules/for-each": {
@@ -3097,22 +3119,22 @@
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node_modules/nise": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-            "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+            "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/fake-timers": "^7.0.4",
                 "@sinonjs/text-encoding": "^0.7.1",
                 "just-extend": "^4.0.2",
-                "lolex": "^5.0.1",
                 "path-to-regexp": "^1.7.0"
             }
         },
-        "node_modules/nise/node_modules/lolex": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
@@ -3914,28 +3936,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/sinon"
-            }
-        },
-        "node_modules/sinon/node_modules/nise": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-            "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^1.7.0",
-                "@sinonjs/fake-timers": "^7.0.4",
-                "@sinonjs/text-encoding": "^0.7.1",
-                "just-extend": "^4.0.2",
-                "path-to-regexp": "^1.7.0"
-            }
-        },
-        "node_modules/sinon/node_modules/nise/node_modules/@sinonjs/fake-timers": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^1.7.0"
             }
         },
         "node_modules/source-map": {
@@ -4986,13 +4986,15 @@
                 "traverse": "^0.6.6"
             },
             "dependencies": {
-                "@sinonjs/formatio": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-                    "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+                "@sinonjs/samsam": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+                    "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
                     "dev": true,
                     "requires": {
-                        "samsam": "1.3.0"
+                        "@sinonjs/commons": "^1.3.0",
+                        "array-from": "^2.1.1",
+                        "lodash": "^4.17.15"
                     }
                 },
                 "diff": {
@@ -5006,6 +5008,40 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
+                },
+                "nise": {
+                    "version": "1.5.3",
+                    "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+                    "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/formatio": "^3.2.1",
+                        "@sinonjs/text-encoding": "^0.7.1",
+                        "just-extend": "^4.0.2",
+                        "lolex": "^5.0.1",
+                        "path-to-regexp": "^1.7.0"
+                    },
+                    "dependencies": {
+                        "@sinonjs/formatio": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+                            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+                            "dev": true,
+                            "requires": {
+                                "@sinonjs/commons": "^1",
+                                "@sinonjs/samsam": "^3.1.0"
+                            }
+                        },
+                        "lolex": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+                            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+                            "dev": true,
+                            "requires": {
+                                "@sinonjs/commons": "^1.7.0"
+                            }
+                        }
+                    }
                 },
                 "sinon": {
                     "version": "4.5.0",
@@ -5052,26 +5088,12 @@
             }
         },
         "@sinonjs/formatio": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+            "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
             "dev": true,
             "requires": {
-                "@sinonjs/commons": "^1",
-                "@sinonjs/samsam": "^3.1.0"
-            },
-            "dependencies": {
-                "@sinonjs/samsam": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-                    "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/commons": "^1.3.0",
-                        "array-from": "^2.1.1",
-                        "lodash": "^4.17.15"
-                    }
-                }
+                "samsam": "1.3.0"
             }
         },
         "@sinonjs/samsam": {
@@ -5210,9 +5232,9 @@
             "dev": true
         },
         "aws-sdk": {
-            "version": "2.1062.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1062.0.tgz",
-            "integrity": "sha512-QIU8jwi7Uqyvw2HjsXXXUZv3V/6TinUzLewrdl2EdvonqZCXhwMgnZx2F9I2x62IKH1RqnINwFWdoK+OTgcAjA==",
+            "version": "2.1063.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz",
+            "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -5334,9 +5356,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001301",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
             "dev": true
         },
         "cfn-stack-event-stream": {
@@ -5638,9 +5660,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.52",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.52.tgz",
-            "integrity": "sha512-JGkh8HEh5PnVrhU4HbpyyO0O791dVY6k7AdqfDeqbcRMeoGxtNHWT77deR2nhvbLe4dKpxjlDEvdEwrvRLGu2Q==",
+            "version": "1.4.53",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
+            "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
             "dev": true
         },
         "emoji-regex": {
@@ -6018,9 +6040,9 @@
             }
         },
         "flatted": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-            "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
         },
         "for-each": {
@@ -6920,22 +6942,22 @@
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "nise": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-            "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+            "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/fake-timers": "^7.0.4",
                 "@sinonjs/text-encoding": "^0.7.1",
                 "just-extend": "^4.0.2",
-                "lolex": "^5.0.1",
                 "path-to-regexp": "^1.7.0"
             },
             "dependencies": {
-                "lolex": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-                    "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+                "@sinonjs/fake-timers": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+                    "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
                     "dev": true,
                     "requires": {
                         "@sinonjs/commons": "^1.7.0"
@@ -7542,32 +7564,6 @@
                 "diff": "^5.0.0",
                 "nise": "^5.1.0",
                 "supports-color": "^7.2.0"
-            },
-            "dependencies": {
-                "nise": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-                    "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/commons": "^1.7.0",
-                        "@sinonjs/fake-timers": "^7.0.4",
-                        "@sinonjs/text-encoding": "^0.7.1",
-                        "just-extend": "^4.0.2",
-                        "path-to-regexp": "^1.7.0"
-                    },
-                    "dependencies": {
-                        "@sinonjs/fake-timers": {
-                            "version": "7.1.2",
-                            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-                            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-                            "dev": true,
-                            "requires": {
-                                "@sinonjs/commons": "^1.7.0"
-                            }
-                        }
-                    }
-                }
             }
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "node": ">= 16"
     },
     "repository": {
-        "url": "https://github.com/mapbox/cfn-config.git",
+        "url": "https://github.com/openaddresses/cfn-config.git",
         "type": "git"
     },
     "bin": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "cfn-stack-event-stream": "^1.0.1",
         "colors": "1.4.0",
         "cuid": "^2.1.1",
-        "d3-queue": "^3.0.2",
         "diff": "^5.0.0",
         "easy-table": "^1.0.0",
         "fasterror": "^1.0.0",
@@ -38,6 +37,7 @@
     },
     "devDependencies": {
         "@mapbox/mock-aws-sdk-js": "^1.0.0",
+        "d3-queue": "^3.0.2",
         "eslint": "^8.1.0",
         "nyc": "^15.0.0",
         "opener": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openaddresses/cfn-config",
-    "version": "3.2.1",
+    "version": "4.0.0",
     "author": "Mapbox",
     "description": "Quickly configure and start AWS CloudFormation stacks",
     "license": "BSD-2-Clause",

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -5,7 +5,7 @@ const test = require('tape');
 const AWS = require('@mapbox/mock-aws-sdk-js');
 const Actions = require('../lib/actions');
 
-test('[actions.diff] stack does not exist', async (t) => {
+test('[actions.diff] stack does not exist', async(t) => {
     AWS.stub('CloudFormation', 'createChangeSet', () => {
         const err = new Error('Stack [my-stack] does not exist');
         err.code = 'ValidationError';
@@ -23,7 +23,7 @@ test('[actions.diff] stack does not exist', async (t) => {
     t.end();
 });
 
-test('[actions.diff] invalid parameters', async (t) => {
+test('[actions.diff] invalid parameters', async(t) => {
     AWS.stub('CloudFormation', 'createChangeSet', () => {
         const err = new Error('Parameters: [Pets, Age, Name, LuckyNumbers, SecretPassword] must have values');
         err.code = 'ValidationError';
@@ -32,7 +32,7 @@ test('[actions.diff] invalid parameters', async (t) => {
 
     try {
         await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
-        t.fail()
+        t.fail();
     } catch (err) {
         t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
     }
@@ -41,7 +41,7 @@ test('[actions.diff] invalid parameters', async (t) => {
     t.end();
 });
 
-test('[actions.diff] template url does not exist', async (t) => {
+test('[actions.diff] template url does not exist', async(t) => {
     AWS.stub('CloudFormation', 'createChangeSet', () => {
         const err = new Error('Template file referenced by https://my-bucket.s3.amazonaws.com/my-template.json does not exist.');
         err.code = 'ValidationError';
@@ -59,7 +59,7 @@ test('[actions.diff] template url does not exist', async (t) => {
     t.end();
 });
 
-test('[actions.diff] template url is invalid', async (t) => {
+test('[actions.diff] template url is invalid', async(t) => {
     AWS.stub('CloudFormation', 'createChangeSet', () => {
         const err = new Error('The specified url must be an Amazon S3 URL.');
         err.code = 'ValidationError';
@@ -77,7 +77,7 @@ test('[actions.diff] template url is invalid', async (t) => {
     t.end();
 });
 
-test('[actions.diff] template is invalid', async (t) => {
+test('[actions.diff] template is invalid', async(t) => {
     AWS.stub('CloudFormation', 'createChangeSet', () => {
         const err = new Error('Template format error: At least one Resources member must be defined.');
         err.code = 'ValidationError';
@@ -95,7 +95,7 @@ test('[actions.diff] template is invalid', async (t) => {
     t.end();
 });
 
-test('[actions.diff] createChangeSet error on wrong changeSetType', async (t) => {
+test('[actions.diff] createChangeSet error on wrong changeSetType', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
     AWS.stub('CloudFormation', 'createChangeSet', () => {
@@ -115,7 +115,7 @@ test('[actions.diff] createChangeSet error on wrong changeSetType', async (t) =>
     t.end();
 });
 
-test('[actions.diff] unexpected createChangeSet error', async (t) => {
+test('[actions.diff] unexpected createChangeSet error', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
     AWS.stub('CloudFormation', 'createChangeSet', () => {
@@ -133,7 +133,7 @@ test('[actions.diff] unexpected createChangeSet error', async (t) => {
     t.end();
 });
 
-test('[actions.diff] unexpected describeChangeSet error', async (t) => {
+test('[actions.diff] unexpected describeChangeSet error', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
     AWS.stub('CloudFormation', 'createChangeSet').returns({
@@ -155,7 +155,7 @@ test('[actions.diff] unexpected describeChangeSet error', async (t) => {
     t.end();
 });
 
-test('[actions.diff] changeset failed to create', async (t) => {
+test('[actions.diff] changeset failed to create', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
     let changesetId;
 
@@ -191,7 +191,7 @@ test('[actions.diff] changeset failed to create', async (t) => {
     t.end();
 });
 
-test('[actions.diff] success', async (t) => {
+test('[actions.diff] success', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
     let changesetId;
     let polled = 0;
@@ -252,7 +252,7 @@ test('[actions.diff] success', async (t) => {
                         Replacement: 'False'
                     }
                 }]
-            }))
+            }));
         } else if (polled === 3) {
             return this.request.promise.returns(Promise.resolve({
                 ChangeSetName: changesetId,
@@ -339,7 +339,7 @@ test('[actions.diff] success', async (t) => {
     t.end();
 });
 
-test('[actions.executeChangeSet] describeChangeSet error', async (t) => {
+test('[actions.executeChangeSet] describeChangeSet error', async(t) => {
     AWS.stub('CloudFormation', 'describeChangeSet', () => {
         throw new Error('unexpected');
     });
@@ -355,7 +355,7 @@ test('[actions.executeChangeSet] describeChangeSet error', async (t) => {
     t.end();
 });
 
-test('[actions.executeChangeSet] changeset not executable', async (t) => {
+test('[actions.executeChangeSet] changeset not executable', async(t) => {
     AWS.stub('CloudFormation', 'describeChangeSet').returns({
         promise: () => Promise.resolve({
             ExecutionStatus: 'UNAVAILABLE',
@@ -378,7 +378,7 @@ test('[actions.executeChangeSet] changeset not executable', async (t) => {
     t.end();
 });
 
-test('[actions.executeChangeSet] executeChangeSet error', async (t) => {
+test('[actions.executeChangeSet] executeChangeSet error', async(t) => {
     AWS.stub('CloudFormation', 'describeChangeSet').returns({
         promise: () => Promise.resolve({
             ExecutionStatus: 'AVAILABLE',
@@ -401,7 +401,7 @@ test('[actions.executeChangeSet] executeChangeSet error', async (t) => {
     t.end();
 });
 
-test('[actions.executeChangeSet] success', async (t) => {
+test('[actions.executeChangeSet] success', async(t) => {
     AWS.stub('CloudFormation', 'describeChangeSet', function(params) {
         t.deepEqual(params, {
             ChangeSetName: 'changeset-id',
@@ -434,7 +434,7 @@ test('[actions.executeChangeSet] success', async (t) => {
     t.end();
 });
 
-test('[actions.delete] stack does not exist', async (t) => {
+test('[actions.delete] stack does not exist', async(t) => {
     AWS.stub('CloudFormation', 'deleteStack', () => {
         const err = new Error('Stack [my-stack] does not exist');
         err.code = 'ValidationError';
@@ -452,7 +452,7 @@ test('[actions.delete] stack does not exist', async (t) => {
     t.end();
 });
 
-test('[actions.delete] unexpected cloudformation error', async (t) => {
+test('[actions.delete] unexpected cloudformation error', async(t) => {
     AWS.stub('CloudFormation', 'deleteStack', () => {
         throw new Error('unexpected');
     });
@@ -468,7 +468,7 @@ test('[actions.delete] unexpected cloudformation error', async (t) => {
     t.end();
 });
 
-test('[actions.delete] success', async (t) => {
+test('[actions.delete] success', async(t) => {
     AWS.stub('CloudFormation', 'deleteStack', function(params) {
         t.deepEqual(params, { StackName: 'my-stack' }, 'deleteStack with expected params');
         return this.request.promise.returns(Promise.resolve());
@@ -484,7 +484,7 @@ test('[actions.delete] success', async (t) => {
     t.end();
 });
 
-test('[actions.validate] unexpected validateTemplate error', async (t) => {
+test('[actions.validate] unexpected validateTemplate error', async(t) => {
     const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
     AWS.stub('CloudFormation', 'validateTemplate', (params) => {
@@ -503,7 +503,7 @@ test('[actions.validate] unexpected validateTemplate error', async (t) => {
     t.end();
 });
 
-test('[actions.validate] invalid template', async (t) => {
+test('[actions.validate] invalid template', async(t) => {
     AWS.stub('CloudFormation', 'validateTemplate', () => {
         const err = new Error('Unresolved resource dependencies [Name] in the Outputs block of the template');
         err.code = 'ValidationError';
@@ -521,7 +521,7 @@ test('[actions.validate] invalid template', async (t) => {
     t.end();
 });
 
-test('[actions.validate] valid template', async (t) => {
+test('[actions.validate] valid template', async(t) => {
     AWS.stub('CloudFormation', 'validateTemplate', function(params) {
         t.deepEqual(params, {
             TemplateURL: 'https://my-bucket.s3.amazonaws.com/my-template.json'
@@ -540,7 +540,7 @@ test('[actions.validate] valid template', async (t) => {
     t.end();
 });
 
-test('[actions.saveConfiguration] bucket does not exist', async (t) => {
+test('[actions.saveConfiguration] bucket does not exist', async(t) => {
     const parameters = {
         Name: 'Chuck',
         Age: 18,
@@ -571,7 +571,7 @@ test('[actions.saveConfiguration] bucket does not exist', async (t) => {
     t.end();
 });
 
-test('[actions.saveConfiguration] unexpected putObject error', async (t) => {
+test('[actions.saveConfiguration] unexpected putObject error', async(t) => {
     const parameters = {
         Name: 'Chuck',
         Age: 18,
@@ -600,7 +600,7 @@ test('[actions.saveConfiguration] unexpected putObject error', async (t) => {
     t.end();
 });
 
-test('[actions.saveConfiguration] success with encryption', async (t) => {
+test('[actions.saveConfiguration] success with encryption', async(t) => {
     const parameters = {
         Name: 'Chuck',
         Age: 18,
@@ -636,7 +636,7 @@ test('[actions.saveConfiguration] success with encryption', async (t) => {
     t.end();
 });
 
-test('[actions.saveConfiguration] success without encryption', async (t) => {
+test('[actions.saveConfiguration] success without encryption', async(t) => {
     const parameters = {
         Name: 'Chuck',
         Age: 18,
@@ -670,7 +670,7 @@ test('[actions.saveConfiguration] success without encryption', async (t) => {
     t.end();
 });
 
-test('[actions.saveConfiguration] config bucket in a different region', async (t) => {
+test('[actions.saveConfiguration] config bucket in a different region', async(t) => {
     const parameters = {
         Name: 'Chuck',
         Age: 18,
@@ -729,7 +729,7 @@ test('[actions.templateUrl] eu-central-1', (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] bucket does not exist', async (t) => {
+test('[actions.saveTemplate] bucket does not exist', async(t) => {
     const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
     const AWS = require('aws-sdk');
@@ -756,7 +756,7 @@ test('[actions.saveTemplate] bucket does not exist', async (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] s3 error', async (t) => {
+test('[actions.saveTemplate] s3 error', async(t) => {
     const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
     AWS.stub('S3', 'putObject', () => {
@@ -774,7 +774,7 @@ test('[actions.saveTemplate] s3 error', async (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] us-east-1', async (t) => {
+test('[actions.saveTemplate] us-east-1', async(t) => {
     const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
 
@@ -800,7 +800,7 @@ test('[actions.saveTemplate] us-east-1', async (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] needs whitespace removal', async (t) => {
+test('[actions.saveTemplate] needs whitespace removal', async(t) => {
     const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = require('./fixtures/huge-template');
 
@@ -824,13 +824,13 @@ test('[actions.saveTemplate] needs whitespace removal', async (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] cn-north-1', async (t) => {
+test('[actions.saveTemplate] cn-north-1', async(t) => {
     const url = 'https://s3-cn-north-1.amazonaws.com.cn/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
     const AWS = require('aws-sdk');
     const S3 = AWS.S3;
 
-    AWS.S3 = (params) => {
+    AWS.S3 = function(params) {
         t.deepEqual(params, { region: 'cn-north-1', signatureVersion: 'v4' }, 'parses cn-north-1 from s3 url');
     };
 
@@ -840,7 +840,10 @@ test('[actions.saveTemplate] cn-north-1', async (t) => {
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: template
         }, 'template put to expected s3 destination');
-        return this.request.promise.returns(Promise.resolve());
+
+        return {
+            promise: () => Promise.resolve()
+        };
     };
 
     try {
@@ -853,13 +856,13 @@ test('[actions.saveTemplate] cn-north-1', async (t) => {
     t.end();
 });
 
-test('[actions.saveTemplate] eu-central-1', async (t) => {
+test('[actions.saveTemplate] eu-central-1', async(t) => {
     const url = 'https://s3-eu-central-1.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
     const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
     const AWS = require('aws-sdk');
     const S3 = AWS.S3;
 
-    AWS.S3 = (params) => {
+    AWS.S3 = function(params) {
         t.deepEqual(params, { region: 'eu-central-1', signatureVersion: 'v4' }, 'parses eu-central-1 from s3 url');
     };
     AWS.S3.prototype.putObject = function(params) {
@@ -868,7 +871,9 @@ test('[actions.saveTemplate] eu-central-1', async (t) => {
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: template
         }, 'template put to expected s3 destination');
-        return this.request.promise.returns(Promise.resolve());
+        return {
+            promise: () => Promise.resolve()
+        };
     };
 
     try {
@@ -881,21 +886,24 @@ test('[actions.saveTemplate] eu-central-1', async (t) => {
     t.end();
 });
 
-test('[actions.monitor] error', async (t) => {
-    AWS.stub('CloudFormation', 'describeStackEvents', function(params, callback) {
-        callback(new Error('failure'));
-        return new events.EventEmitter();
+test('[actions.monitor] error', async(t) => {
+    AWS.stub('CloudFormation', 'describeStackEvents', () => {
+        throw new Error('failure');
     });
 
-    Actions.monitor('my-stack', 'us-east-1', function(err) {
+    try {
+        await Actions.monitor('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
         t.ok(err instanceof Actions.CloudFormationError, 'expected error type');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.monitor] success', async (t) => {
-    var once = true;
+test('[actions.monitor] success', async(t) => {
+    let once = true;
 
     AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
         setTimeout(callback, 1000, null, {
@@ -949,9 +957,12 @@ test('[actions.monitor] success', async (t) => {
         return new events.EventEmitter();
     });
 
-    Actions.monitor('my-stack', 'us-east-1', function(err) {
-        t.ifError(err, 'success');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.monitor('my-stack', 'us-east-1');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -3,164 +3,200 @@ const fs = require('fs');
 const events = require('events');
 const test = require('tape');
 const AWS = require('@mapbox/mock-aws-sdk-js');
-const actions = require('../lib/actions');
+const Actions = require('../lib/actions');
 
-test('[actions.diff] stack does not exist', (t) => {
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('Stack [my-stack] does not exist');
+test('[actions.diff] stack does not exist', async (t) => {
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('Stack [my-stack] does not exist');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] invalid parameters', (t) => {
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('Parameters: [Pets, Age, Name, LuckyNumbers, SecretPassword] must have values');
+test('[actions.diff] invalid parameters', async (t) => {
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('Parameters: [Pets, Age, Name, LuckyNumbers, SecretPassword] must have values');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
+        t.fail()
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] template url does not exist', (t) => {
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('Template file referenced by https://my-bucket.s3.amazonaws.com/my-template.json does not exist.');
+test('[actions.diff] template url does not exist', async (t) => {
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('Template file referenced by https://my-bucket.s3.amazonaws.com/my-template.json does not exist.');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] template url is invalid', (t) => {
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('The specified url must be an Amazon S3 URL.');
+test('[actions.diff] template url is invalid', async (t) => {
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('The specified url must be an Amazon S3 URL.');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] template is invalid', (t) => {
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('Template format error: At least one Resources member must be defined.');
+test('[actions.diff] template is invalid', async (t) => {
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('Template format error: At least one Resources member must be defined.');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] createChangeSet error on wrong changeSetType', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+test('[actions.diff] createChangeSet error on wrong changeSetType', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        var err = new Error('\'INVALID\' at \'changeSetType\' failed to satisfy constraint: Member must satisfy enum value set: [UPDATE, CREATE]');
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        const err = new Error('\'INVALID\' at \'changeSetType\' failed to satisfy constraint: Member must satisfy enum value set: [UPDATE, CREATE]');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.diff('my-stack', 'us-east-1', 'INVALID', url, {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'INVALID', url, {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] unexpected createChangeSet error', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+test('[actions.diff] unexpected createChangeSet error', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        callback(new Error('unexpected'));
+    AWS.stub('CloudFormation', 'createChangeSet', () => {
+        throw new Error('unexpected');
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await  Actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] unexpected describeChangeSet error', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+test('[actions.diff] unexpected describeChangeSet error', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
-        callback(null, { Id: 'changeset:arn' });
+    AWS.stub('CloudFormation', 'createChangeSet').returns({
+        promise: () => Promise.resolve({ Id: 'changeset:arn' })
     });
 
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
-        callback(new Error('unexpected'));
+    AWS.stub('CloudFormation', 'describeChangeSet', () => {
+        throw new Error('unexpected');
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] changeset failed to create', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
-    var changesetId;
+test('[actions.diff] changeset failed to create', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+    let changesetId;
 
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
+    AWS.stub('CloudFormation', 'createChangeSet', function(params) {
         changesetId = params.ChangeSetName;
-        callback(null, { Id: 'changeset:arn' });
+        return this.request.promise.returns(Promise.resolve({ Id: 'changeset:arn' }));
     });
 
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
-        callback(null, {
+    AWS.stub('CloudFormation', 'describeChangeSet').returns({
+        promise: () => Promise.resolve({
             ChangeSetName: changesetId,
             ChangeSetId: 'changeset:arn',
             StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
             StackName: 'my-stack',
             ExecutionStatus: 'UNAVAILABLE',
             Status: 'FAILED'
-        });
+        })
     });
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err, data) {
-        t.ifError(err, 'success');
+    try {
+        const data = await Actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false);
+
         t.deepEqual(data, {
             id: changesetId,
             status: 'FAILED',
             execution: 'UNAVAILABLE'
         }, 'returned changeset details');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.diff] success', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
-    var changesetId;
-    var polled = 0;
+test('[actions.diff] success', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+    let changesetId;
+    let polled = 0;
 
-    AWS.stub('CloudFormation', 'createChangeSet', function(params, callback) {
+    AWS.stub('CloudFormation', 'createChangeSet', function(params) {
         t.ok(/^[\w\d-]{1,128}$/.test(params.ChangeSetName), 'createChangeSet valid change set name');
         t.deepEqual(params, {
             ChangeSetName: params.ChangeSetName,
@@ -179,65 +215,68 @@ test('[actions.diff] success', (t) => {
         }, 'createChangeSet expected parameters');
 
         changesetId = params.ChangeSetName;
-        callback(null, { Id: 'changeset:arn' });
+        return this.request.promise.returns(Promise.resolve({ Id: 'changeset:arn' }));
     });
 
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
+    AWS.stub('CloudFormation', 'describeChangeSet', function(params) {
         polled++;
         t.equal(params.ChangeSetName, changesetId, 'describe correct changeset');
         t.equal(params.StackName, 'my-stack', 'describe correct stackname');
         if (params.NextToken) t.equal(params.NextToken, 'xxx', 'used next token to paginate');
 
-        if (polled === 1) return callback(null, { ChangeSetName: changesetId,
-            ChangeSetId: 'changeset:arn1',
-            StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
-            StackName: 'my-stack',
-            ExecutionStatus: 'AVAILABLE',
-            Status: 'CREATE_IN_PROGRESS',
-            Changes: []
-        });
-
-        if (polled === 2) return callback(null, {
-            ChangeSetName: changesetId,
-            ChangeSetId: 'changeset:arn1',
-            StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
-            StackName: 'my-stack',
-            ExecutionStatus: 'AVAILABLE',
-            Status: 'CREATE_IN_PROGRESS',
-            Changes: [{
-                Type: 'Resource',
-                ResourceChange: {
-                    Action: 'Modify',
-                    LogicalResourceId: 'Topic',
-                    PhysicalResourceId: 'arn:aws:sns:us-east-1:123456789012:another-stack-Topic-ABCDEFGHIJKL',
-                    ResourceType: 'AWS::SNS::Topic',
-                    Replacement: 'False'
-                }
-            }]
-        });
-
-        if (polled === 3) return callback(null, {
-            ChangeSetName: changesetId,
-            ChangeSetId: 'changeset:arn1',
-            StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
-            StackName: 'my-stack',
-            ExecutionStatus: 'AVAILABLE',
-            Status: 'CREATE_COMPLETE',
-            Changes: [{
-                Type: 'Resource',
-                ResourceChange: {
-                    Action: 'Modify',
-                    LogicalResourceId: 'Topic',
-                    PhysicalResourceId: 'arn:aws:sns:us-east-1:123456789012:another-stack-Topic-ABCDEFGHIJKL',
-                    ResourceType: 'AWS::SNS::Topic',
-                    Replacement: 'False'
-                }
-            }],
-            NextToken: 'xxx'
-        });
+        if (polled === 1) {
+            return this.request.promise.returns(Promise.resolve({
+                ChangeSetName: changesetId,
+                ChangeSetId: 'changeset:arn1',
+                StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
+                StackName: 'my-stack',
+                ExecutionStatus: 'AVAILABLE',
+                Status: 'CREATE_IN_PROGRESS',
+                Changes: []
+            }));
+        } else if (polled === 2) {
+            return this.request.promise.returns(Promise.resolve({
+                ChangeSetName: changesetId,
+                ChangeSetId: 'changeset:arn1',
+                StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
+                StackName: 'my-stack',
+                ExecutionStatus: 'AVAILABLE',
+                Status: 'CREATE_IN_PROGRESS',
+                Changes: [{
+                    Type: 'Resource',
+                    ResourceChange: {
+                        Action: 'Modify',
+                        LogicalResourceId: 'Topic',
+                        PhysicalResourceId: 'arn:aws:sns:us-east-1:123456789012:another-stack-Topic-ABCDEFGHIJKL',
+                        ResourceType: 'AWS::SNS::Topic',
+                        Replacement: 'False'
+                    }
+                }]
+            }))
+        } else if (polled === 3) {
+            return this.request.promise.returns(Promise.resolve({
+                ChangeSetName: changesetId,
+                ChangeSetId: 'changeset:arn1',
+                StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
+                StackName: 'my-stack',
+                ExecutionStatus: 'AVAILABLE',
+                Status: 'CREATE_COMPLETE',
+                Changes: [{
+                    Type: 'Resource',
+                    ResourceChange: {
+                        Action: 'Modify',
+                        LogicalResourceId: 'Topic',
+                        PhysicalResourceId: 'arn:aws:sns:us-east-1:123456789012:another-stack-Topic-ABCDEFGHIJKL',
+                        ResourceType: 'AWS::SNS::Topic',
+                        Replacement: 'False'
+                    }
+                }],
+                NextToken: 'xxx'
+            }));
+        }
 
         // This is a partial response object
-        callback(null, {
+        return this.request.promise.returns(Promise.resolve({
             ChangeSetName: 'aa507e2bdfc55947035a07271e75384efe',
             ChangeSetId: 'changeset:arn',
             StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/be3aa370-5b64-11e6-a232-500c217dbe62',
@@ -256,10 +295,10 @@ test('[actions.diff] success', (t) => {
                     }
                 }
             ]
-        });
+        }));
     });
 
-    var parameters = [
+    const parameters = [
         { ParameterKey: 'Name', ParameterValue: 'Chuck' },
         { ParameterKey: 'Age', ParameterValue: 18 },
         { ParameterKey: 'Handedness', ParameterValue: 'right' },
@@ -268,8 +307,9 @@ test('[actions.diff] success', (t) => {
         { ParameterKey: 'SecretPassword', ParameterValue: 'secret' }
     ];
 
-    actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, true, function(err, data) {
-        t.ifError(err, 'success');
+    try {
+        const data = await Actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, true);
+
         t.deepEqual(data, {
             id: 'aa507e2bdfc55947035a07271e75384efe',
             status: 'CREATE_COMPLETE',
@@ -291,177 +331,217 @@ test('[actions.diff] success', (t) => {
                 }
             ]
         }, 'returned changeset details');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.executeChangeSet] describeChangeSet error', (t) => {
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
-        callback(new Error('unexpected'));
+test('[actions.executeChangeSet] describeChangeSet error', async (t) => {
+    AWS.stub('CloudFormation', 'describeChangeSet', () => {
+        throw new Error('unexpected');
     });
 
-    actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.executeChangeSet] changeset not executable', (t) => {
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
-        callback(null, {
+test('[actions.executeChangeSet] changeset not executable', async (t) => {
+    AWS.stub('CloudFormation', 'describeChangeSet').returns({
+        promise: () => Promise.resolve({
             ExecutionStatus: 'UNAVAILABLE',
             Status: 'CREATE_COMPLETE',
             StatusReason: 'because I said so'
-        });
+        })
     });
 
-    actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id', function(err) {
-        t.ok(err instanceof actions.ChangeSetNotExecutableError, 'expected error');
+    try {
+        await Actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.ChangeSetNotExecutableError, 'expected error');
         t.equal(err.execution, 'UNAVAILABLE', 'err object exposes execution status');
         t.equal(err.status, 'CREATE_COMPLETE', 'err object exposes status');
         t.equal(err.reason, 'because I said so', 'err object exposes status reason');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.executeChangeSet] executeChangeSet error', (t) => {
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
-        callback(null, {
+test('[actions.executeChangeSet] executeChangeSet error', async (t) => {
+    AWS.stub('CloudFormation', 'describeChangeSet').returns({
+        promise: () => Promise.resolve({
             ExecutionStatus: 'AVAILABLE',
             Status: 'CREATE_COMPLETE'
-        });
+        })
     });
 
-    AWS.stub('CloudFormation', 'executeChangeSet', function(params, callback) {
-        callback(new Error('unexpected'));
+    AWS.stub('CloudFormation', 'executeChangeSet', () => {
+        throw new Error('unexpected');
     });
 
-    actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id');
+        t.fail();
+    } catch(err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.executeChangeSet] success', (t) => {
-    AWS.stub('CloudFormation', 'describeChangeSet', function(params, callback) {
+test('[actions.executeChangeSet] success', async (t) => {
+    AWS.stub('CloudFormation', 'describeChangeSet', function(params) {
         t.deepEqual(params, {
             ChangeSetName: 'changeset-id',
             StackName: 'my-stack',
             NextToken: undefined
         }, 'expected params provided to describeChangeSet');
 
-        callback(null, {
+        return this.request.promise.returns(Promise.resolve({
             ExecutionStatus: 'AVAILABLE',
             Status: 'CREATE_COMPLETE'
-        });
+        }));
     });
 
-    AWS.stub('CloudFormation', 'executeChangeSet', function(params, callback) {
+    AWS.stub('CloudFormation', 'executeChangeSet', function(params) {
         t.deepEqual(params, {
             ChangeSetName: 'changeset-id',
             StackName: 'my-stack'
         }, 'expected params provided to executeChangeSet');
 
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id', function(err) {
-        t.ifError(err, 'success');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.executeChangeSet('my-stack', 'us-east-1', 'changeset-id');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.delete] stack does not exist', (t) => {
-    AWS.stub('CloudFormation', 'deleteStack', function(params, callback) {
-        var err = new Error('Stack [my-stack] does not exist');
+test('[actions.delete] stack does not exist', async (t) => {
+    AWS.stub('CloudFormation', 'deleteStack', () => {
+        const err = new Error('Stack [my-stack] does not exist');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.delete('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.delete('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.delete] unexpected cloudformation error', (t) => {
-    AWS.stub('CloudFormation', 'deleteStack', function(params, callback) {
-        callback(new Error('unexpected'));
+test('[actions.delete] unexpected cloudformation error', async (t) => {
+    AWS.stub('CloudFormation', 'deleteStack', () => {
+        throw new Error('unexpected');
     });
 
-    actions.delete('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.delete('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.delete] success', (t) => {
-    AWS.stub('CloudFormation', 'deleteStack', function(params, callback) {
+test('[actions.delete] success', async (t) => {
+    AWS.stub('CloudFormation', 'deleteStack', function(params) {
         t.deepEqual(params, { StackName: 'my-stack' }, 'deleteStack with expected params');
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.delete('my-stack', 'us-east-1', function(err) {
-        t.ifError(err, 'success');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.delete('my-stack', 'us-east-1');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.validate] unexpected validateTemplate error', (t) => {
-    var url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
+test('[actions.validate] unexpected validateTemplate error', async (t) => {
+    const url = 'https://my-bucket.s3.amazonaws.com/my-template.json';
 
-    AWS.stub('CloudFormation', 'validateTemplate', function(params, callback) {
+    AWS.stub('CloudFormation', 'validateTemplate', (params) => {
         t.deepEqual(params, { TemplateURL: url }, 'validateTemplate with expected params');
-        callback(new Error('unexpected'));
+        throw new Error('unexpected');
     });
 
-    actions.validate('us-east-1', url, function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.validate('us-east-1', url);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.validate] invalid template', (t) => {
-    AWS.stub('CloudFormation', 'validateTemplate', function(params, callback) {
-        var err = new Error('Unresolved resource dependencies [Name] in the Outputs block of the template');
+test('[actions.validate] invalid template', async (t) => {
+    AWS.stub('CloudFormation', 'validateTemplate', () => {
+        const err = new Error('Unresolved resource dependencies [Name] in the Outputs block of the template');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    actions.validate('us-east-1', 'https://my-bucket.s3.amazonaws.com/my-template.json', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error type');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.validate('us-east-1', 'https://my-bucket.s3.amazonaws.com/my-template.json');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error type');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.validate] valid template', (t) => {
-    AWS.stub('CloudFormation', 'validateTemplate', function(params, callback) {
+test('[actions.validate] valid template', async (t) => {
+    AWS.stub('CloudFormation', 'validateTemplate', function(params) {
         t.deepEqual(params, {
             TemplateURL: 'https://my-bucket.s3.amazonaws.com/my-template.json'
         }, 'expected params passed to validateTemplate');
 
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.validate('us-east-1', 'https://my-bucket.s3.amazonaws.com/my-template.json', function(err) {
-        t.ifError(err, 'success');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Actions.validate('us-east-1', 'https://my-bucket.s3.amazonaws.com/my-template.json');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[actions.saveConfiguration] bucket does not exist', (t) => {
-    var parameters = {
+test('[actions.saveConfiguration] bucket does not exist', async (t) => {
+    const parameters = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -470,25 +550,29 @@ test('[actions.saveConfiguration] bucket does not exist', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
-        var err = new Error('The specified bucket does not exist');
+    AWS.stub('S3', 'putObject', () => {
+        const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
-        t.ok(err instanceof actions.BucketNotFoundError, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.BucketNotFoundError, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveConfiguration] unexpected putObject error', (t) => {
-    var parameters = {
+test('[actions.saveConfiguration] unexpected putObject error', async (t) => {
+    const parameters = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -497,23 +581,27 @@ test('[actions.saveConfiguration] unexpected putObject error', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
-        callback(new Error('unexpected'));
+    AWS.stub('S3', 'putObject', () => {
+        throw new Error('unexpected');
     });
 
-    actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
-        t.ok(err instanceof actions.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveConfiguration] success with encryption', (t) => {
-    var parameters = {
+test('[actions.saveConfiguration] success with encryption', async (t) => {
+    const parameters = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -522,11 +610,11 @@ test('[actions.saveConfiguration] success with encryption', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
+    AWS.stub('S3', 'putObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'my-stack/my-stack-staging-us-east-1.cfn.json',
@@ -534,18 +622,22 @@ test('[actions.saveConfiguration] success with encryption', (t) => {
             ServerSideEncryption: 'aws:kms',
             SSEKMSKeyId: 'my-key'
         }, 'expected putObject parameters');
-        callback();
+
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, 'my-key', function(err) {
-        t.ifError(err, 'success');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, 'my-key');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveConfiguration] success without encryption', (t) => {
-    var parameters = {
+test('[actions.saveConfiguration] success without encryption', async (t) => {
+    const parameters = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -554,28 +646,32 @@ test('[actions.saveConfiguration] success without encryption', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
+    AWS.stub('S3', 'putObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'my-stack/my-stack-staging-us-east-1.cfn.json',
             Body: JSON.stringify(parameters)
         }, 'expected putObject parameters');
-        callback();
+
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
-        t.ifError(err, 'success');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters);
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveConfiguration] config bucket in a different region', (t) => {
-    var parameters = {
+test('[actions.saveConfiguration] config bucket in a different region', async (t) => {
+    const parameters = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -584,194 +680,221 @@ test('[actions.saveConfiguration] config bucket in a different region', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, { LocationConstraint: 'us-east-2' });
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve({ LocationConstraint: 'us-east-2' })
     });
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
+    AWS.stub('S3', 'putObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'my-stack/my-stack-staging-eu-west-1.cfn.json',
             Body: JSON.stringify(parameters)
         }, 'expected putObject parameters');
-        callback();
+
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.saveConfiguration('my-stack', 'my-stack-staging', 'eu-west-1', 'my-bucket', parameters, function(err) {
-        t.ifError(err, 'success');
+    try {
+        await Actions.saveConfiguration('my-stack', 'my-stack-staging', 'eu-west-1', 'my-bucket', parameters);
+
         t.true(AWS.S3.calledTwice, 's3 client setup called twice');
         t.ok(AWS.S3.firstCall.calledWithExactly({ signatureVersion: 'v4', region: 'eu-west-1' }), 'first s3 client created correctly');
         t.ok(AWS.S3.secondCall.calledWithExactly({ region: 'us-east-2', signatureVersion: 'v4' }), 'second s3 client created correctly');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
 test('[actions.templateUrl] us-east-1', (t) => {
-    var url = actions.templateUrl('my-bucket', 'us-east-1', 'my-stack');
-    var re = /https:\/\/s3.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
+    const url = Actions.templateUrl('my-bucket', 'us-east-1', 'my-stack');
+    const re = /https:\/\/s3.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
     t.ok(re.test(url), 'expected url');
     t.end();
 });
 
 test('[actions.templateUrl] cn-north-1', (t) => {
-    var url = actions.templateUrl('my-bucket', 'cn-north-1', 'my-stack');
-    var re = /https:\/\/s3.cn-north-1.amazonaws.com.cn\/my-bucket\/.*-my-stack.template.json/;
+    const url = Actions.templateUrl('my-bucket', 'cn-north-1', 'my-stack');
+    const re = /https:\/\/s3.cn-north-1.amazonaws.com.cn\/my-bucket\/.*-my-stack.template.json/;
     t.ok(re.test(url), 'expected url');
     t.end();
 });
 
 test('[actions.templateUrl] eu-central-1', (t) => {
-    var url = actions.templateUrl('my-bucket', 'eu-central-1', 'my-stack');
-    var re = /https:\/\/s3-eu-central-1.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
+    const url = Actions.templateUrl('my-bucket', 'eu-central-1', 'my-stack');
+    const re = /https:\/\/s3-eu-central-1.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
     t.ok(re.test(url), 'expected url');
     t.end();
 });
 
-test('[actions.saveTemplate] bucket does not exist', (t) => {
-    var url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
-    var AWS = require('aws-sdk');
-    var S3 = AWS.S3;
+test('[actions.saveTemplate] bucket does not exist', async (t) => {
+    const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
+    const AWS = require('aws-sdk');
+    const S3 = AWS.S3;
 
     AWS.S3 = function(params) {
         t.deepEqual(params, { region: 'us-east-1', signatureVersion: 'v4' });
     };
-    AWS.S3.prototype.putObject = function(params, callback) {
-        var err = new Error('The specified bucket does not exist');
+
+    AWS.S3.prototype.putObject = () => {
+        const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     };
 
-    actions.saveTemplate(url, template, function(err) {
-        t.ok(err instanceof actions.BucketNotFoundError, 'expected error returned');
-        AWS.S3 = S3;
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, template);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.BucketNotFoundError, 'expected error returned');
+    }
+
+    AWS.S3 = S3;
+    t.end();
 });
 
-test('[actions.saveTemplate] s3 error', (t) => {
-    var url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
-    AWS.stub('S3', 'putObject', function(params, callback) {
-        callback(new Error('unexpected'));
+test('[actions.saveTemplate] s3 error', async (t) => {
+    const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
+    AWS.stub('S3', 'putObject', () => {
+        throw new Error('unexpected');
     });
 
-    actions.saveTemplate(url, template, function(err) {
-        t.ok(err instanceof actions.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, template);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Actions.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveTemplate] us-east-1', (t) => {
-    var url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
+test('[actions.saveTemplate] us-east-1', async (t) => {
+    const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
 
     // really need a way to stub the client constructor
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
+    AWS.stub('S3', 'putObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: template
         }, 'template put to expected s3 destination');
 
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.saveTemplate(url, template, function(err) {
-        t.ifError(err, 'success');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, template);
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveTemplate] needs whitespace removal', (t) => {
-    var url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = require('./fixtures/huge-template');
+test('[actions.saveTemplate] needs whitespace removal', async (t) => {
+    const url = 'https://s3.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = require('./fixtures/huge-template');
 
-    AWS.stub('S3', 'putObject', function(params, callback) {
+    AWS.stub('S3', 'putObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: JSON.stringify(template)
         }, 'template put to expected s3 destination, and whitespace was removed');
 
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     });
 
-    actions.saveTemplate(url, JSON.stringify(template, null, 2), function(err) {
-        t.ifError(err, 'success');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, JSON.stringify(template, null, 2));
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[actions.saveTemplate] cn-north-1', (t) => {
-    var url = 'https://s3-cn-north-1.amazonaws.com.cn/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
-    var AWS = require('aws-sdk');
-    var S3 = AWS.S3;
+test('[actions.saveTemplate] cn-north-1', async (t) => {
+    const url = 'https://s3-cn-north-1.amazonaws.com.cn/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
+    const AWS = require('aws-sdk');
+    const S3 = AWS.S3;
 
-    AWS.S3 = function(params) {
+    AWS.S3 = (params) => {
         t.deepEqual(params, { region: 'cn-north-1', signatureVersion: 'v4' }, 'parses cn-north-1 from s3 url');
     };
-    AWS.S3.prototype.putObject = function(params, callback) {
+
+    AWS.S3.prototype.putObject = function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: template
         }, 'template put to expected s3 destination');
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     };
 
-    actions.saveTemplate(url, template, function(err) {
-        t.ifError(err, 'success');
-        AWS.S3 = S3;
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, template);
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3 = S3;
+    t.end();
 });
 
-test('[actions.saveTemplate] eu-central-1', (t) => {
-    var url = 'https://s3-eu-central-1.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
-    var template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
-    var AWS = require('aws-sdk');
-    var S3 = AWS.S3;
+test('[actions.saveTemplate] eu-central-1', async (t) => {
+    const url = 'https://s3-eu-central-1.amazonaws.com/my-bucket/cirjpj94c0000s5nzc1j452o7-my-stack.template.json';
+    const template = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'template.json'));
+    const AWS = require('aws-sdk');
+    const S3 = AWS.S3;
 
-    AWS.S3 = function(params) {
+    AWS.S3 = (params) => {
         t.deepEqual(params, { region: 'eu-central-1', signatureVersion: 'v4' }, 'parses eu-central-1 from s3 url');
     };
-    AWS.S3.prototype.putObject = function(params, callback) {
+    AWS.S3.prototype.putObject = function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'cirjpj94c0000s5nzc1j452o7-my-stack.template.json',
             Body: template
         }, 'template put to expected s3 destination');
-        callback();
+        return this.request.promise.returns(Promise.resolve());
     };
 
-    actions.saveTemplate(url, template, function(err) {
-        t.ifError(err, 'success');
-        AWS.S3 = S3;
-        t.end();
-    });
+    try {
+        await Actions.saveTemplate(url, template);
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3 = S3;
+    t.end();
 });
 
-test('[actions.monitor] error', (t) => {
+test('[actions.monitor] error', async (t) => {
     AWS.stub('CloudFormation', 'describeStackEvents', function(params, callback) {
         callback(new Error('failure'));
         return new events.EventEmitter();
     });
 
-    actions.monitor('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof actions.CloudFormationError, 'expected error type');
+    Actions.monitor('my-stack', 'us-east-1', function(err) {
+        t.ok(err instanceof Actions.CloudFormationError, 'expected error type');
         AWS.CloudFormation.restore();
         t.end();
     });
 });
 
-test('[actions.monitor] success', (t) => {
+test('[actions.monitor] success', async (t) => {
     var once = true;
 
     AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
@@ -826,7 +949,7 @@ test('[actions.monitor] success', (t) => {
         return new events.EventEmitter();
     });
 
-    actions.monitor('my-stack', 'us-east-1', function(err) {
+    Actions.monitor('my-stack', 'us-east-1', function(err) {
         t.ifError(err, 'success');
         AWS.CloudFormation.restore();
         t.end();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -121,59 +121,74 @@ const base = {
     }
 };
 
-test('[cli.main] no command', (t) => {
+test('[cli.main] no command', async (t) => {
     const parsed = Object.assign({}, base, { command: undefined });
 
-    cli.main(parsed, function(err) {
+    try {
+        await cli.main(parsed);
+        t.fail();
+    } catch (err) {
         t.equal(err.message, 'Error: invalid command\n\n' + parsed.help, 'expected error message');
-        t.end();
-    });
+    }
+    t.end();
 });
 
-test('[cli.main] bad command', (t) => {
+test('[cli.main] bad command', async (t) => {
     const parsed = Object.assign({}, base, { command: 'hibbity' });
 
-    cli.main(parsed, function(err) {
+    try {
+        await cli.main(parsed);
+        t.fail();
+    } catch (err) {
         t.equal(err.message, 'Error: invalid command\n\n' + parsed.help, 'expected error message');
-        t.end();
-    });
+    }
+
+    t.end();
 });
 
-test('[cli.main] no environment', (t) => {
+test('[cli.main] no environment', async (t) => {
     const parsed = Object.assign({}, base, { environment: undefined });
 
-    cli.main(parsed, function(err) {
+    try {
+        await cli.main(parsed);
+        t.fail();
+    } catch (err) {
         t.equal(err.message, 'Error: missing environment\n\n' + parsed.help, 'expected error message');
-        t.end();
-    });
+    }
+
+    t.end();
 });
 
-test('[cli.main] no template path (create)', (t) => {
+test('[cli.main] no template path (create)', async (t) => {
     const parsed = Object.assign({}, base, { templatePath: undefined });
 
-    cli.main(parsed, function(err) {
+    try {
+        await cli.main(parsed);
+        t.fail();
+    } catch (err) {
         t.equal(err.message, 'Error: missing templatePath\n\n' + parsed.help, 'expected error message');
-        t.end();
-    });
+    }
+
+    t.end();
 });
 
-test('[cli.main] no template path (info)', (t) => {
-    sinon.stub(cfnConfig, 'commands').callsFake(function() {
-        return { info: function() { Array.from(arguments).pop()(); } };
-    });
-
+test('[cli.main] no template path (info)', async (t) => {
     const parsed = Object.assign({}, base, { command: 'info', templatePath: undefined });
 
-    cli.main(parsed, function(err) {
-        t.ifError(err, 'success');
-        cfnConfig.commands.restore();
-        t.end();
-    });
+    try {
+        await cli.main(parsed);
+    } catch (err) {
+        t.error(err);
+    }
+
+    cfnConfig.commands.restore();
+    t.end();
 });
 
-test('[cli.main] create', (t) => {
-    sinon.stub(cfnConfig, 'commands').callsFake(function(options) {
+test('[cli.main] create', async (t) => {
+    sinon.stub(cfnConfig, 'commands').callsFake((options) => {
         t.deepEqual(options, base.options, 'provided commands constructor with correct options');
+
         return {
             create: function(suffix, templatePath, overrides, callback) {
                 t.equal(suffix, base.environment, 'provides correct suffix');
@@ -184,11 +199,14 @@ test('[cli.main] create', (t) => {
         };
     });
 
-    cli.main(base, function(err) {
-        t.ifError(err, 'success');
-        cfnConfig.commands.restore();
-        t.end();
-    });
+    try {
+        await cli.main(base);
+    } catch (err) {
+        t.error(err);
+    }
+
+    cfnConfig.commands.restore();
+    t.end();
 });
 
 test('[cli.main] update', (t) => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -80,7 +80,7 @@ test('[cli.parse] sets options', (t) => {
 });
 
 test('[cli.parse] handles default template bucket on create & update', (t) => {
-    const parsed = cli.parse(['info', 'testing'], {});
+    let parsed = cli.parse(['info', 'testing'], {});
     t.notOk(parsed.options.templateBucket, 'not set when not needed');
 
     parsed = cli.parse(['create', 'testing'], { AWS_ACCOUNT_ID: '123456789012' });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,8 +5,8 @@ const cli = require('../lib/cli');
 const cfnConfig = require('..');
 
 test('[cli.parse] aliases and defaults', (t) => {
-    var args = ['create', 'testing', 'relative/path', '-c', 'config', '-t', 'template'];
-    var parsed = cli.parse(args, {});
+    const args = ['create', 'testing', 'relative/path', '-c', 'config', '-t', 'template'];
+    const parsed = cli.parse(args, {});
 
     t.equal(parsed.command, 'create', 'contains command');
     t.equal(parsed.environment, 'testing', 'contains environment');
@@ -39,7 +39,7 @@ test('[cli.parse] aliases and defaults', (t) => {
 });
 
 test('[cli.parse] sets options', (t) => {
-    var args = [
+    const args = [
         'create', 'testing', 'relative/path',
         '-c', 'config',
         '-t', 'template',
@@ -50,7 +50,7 @@ test('[cli.parse] sets options', (t) => {
         '-p', '{}'
     ];
 
-    var parsed = cli.parse(args, {});
+    const parsed = cli.parse(args, {});
 
     t.deepEqual(parsed.options, {
         d: true,
@@ -80,7 +80,7 @@ test('[cli.parse] sets options', (t) => {
 });
 
 test('[cli.parse] handles default template bucket on create & update', (t) => {
-    var parsed = cli.parse(['info', 'testing'], {});
+    const parsed = cli.parse(['info', 'testing'], {});
     t.notOk(parsed.options.templateBucket, 'not set when not needed');
 
     parsed = cli.parse(['create', 'testing'], { AWS_ACCOUNT_ID: '123456789012' });
@@ -104,7 +104,7 @@ test('[cli.parse] handles default template bucket on create & update', (t) => {
     t.end();
 });
 
-var base = {
+const base = {
     command: 'create',
     environment: 'testing',
     templatePath: '/my/template',
@@ -122,7 +122,7 @@ var base = {
 };
 
 test('[cli.main] no command', (t) => {
-    var parsed = Object.assign({}, base, { command: undefined });
+    const parsed = Object.assign({}, base, { command: undefined });
 
     cli.main(parsed, function(err) {
         t.equal(err.message, 'Error: invalid command\n\n' + parsed.help, 'expected error message');
@@ -131,7 +131,7 @@ test('[cli.main] no command', (t) => {
 });
 
 test('[cli.main] bad command', (t) => {
-    var parsed = Object.assign({}, base, { command: 'hibbity' });
+    const parsed = Object.assign({}, base, { command: 'hibbity' });
 
     cli.main(parsed, function(err) {
         t.equal(err.message, 'Error: invalid command\n\n' + parsed.help, 'expected error message');
@@ -140,7 +140,7 @@ test('[cli.main] bad command', (t) => {
 });
 
 test('[cli.main] no environment', (t) => {
-    var parsed = Object.assign({}, base, { environment: undefined });
+    const parsed = Object.assign({}, base, { environment: undefined });
 
     cli.main(parsed, function(err) {
         t.equal(err.message, 'Error: missing environment\n\n' + parsed.help, 'expected error message');
@@ -149,7 +149,7 @@ test('[cli.main] no environment', (t) => {
 });
 
 test('[cli.main] no template path (create)', (t) => {
-    var parsed = Object.assign({}, base, { templatePath: undefined });
+    const parsed = Object.assign({}, base, { templatePath: undefined });
 
     cli.main(parsed, function(err) {
         t.equal(err.message, 'Error: missing templatePath\n\n' + parsed.help, 'expected error message');
@@ -162,7 +162,7 @@ test('[cli.main] no template path (info)', (t) => {
         return { info: function() { Array.from(arguments).pop()(); } };
     });
 
-    var parsed = Object.assign({}, base, { command: 'info', templatePath: undefined });
+    const parsed = Object.assign({}, base, { command: 'info', templatePath: undefined });
 
     cli.main(parsed, function(err) {
         t.ifError(err, 'success');
@@ -204,7 +204,7 @@ test('[cli.main] update', (t) => {
         };
     });
 
-    var parsed = Object.assign({}, base, { command: 'update' });
+    const parsed = Object.assign({}, base, { command: 'update' });
 
     cli.main(parsed, function(err) {
         t.ifError(err, 'success');
@@ -225,7 +225,7 @@ test('[cli.main] delete', (t) => {
         };
     });
 
-    var parsed = Object.assign({}, base, { command: 'delete' });
+    const parsed = Object.assign({}, base, { command: 'delete' });
 
     cli.main(parsed, function(err) {
         t.ifError(err, 'success');
@@ -247,7 +247,7 @@ test('[cli.main] info', (t) => {
         };
     });
 
-    var parsed = Object.assign({}, base, { command: 'info' });
+    const parsed = Object.assign({}, base, { command: 'info' });
 
     cli.main(parsed, function(err) {
         t.ifError(err, 'success');
@@ -268,7 +268,7 @@ test('[cli.main] save (with kms)', (t) => {
         };
     });
 
-    var parsed = Object.assign({}, base, { command: 'save' });
+    const parsed = Object.assign({}, base, { command: 'save' });
     parsed.overrides.kms = true;
 
     cli.main(parsed, function(err) {
@@ -289,8 +289,7 @@ test('[cli.main] save (without kms)', (t) => {
         };
     });
 
-    var parsed = Object.assign({}, base, { command: 'save' });
-
+    const parsed = Object.assign({}, base, { command: 'save' });
 
     cli.main(parsed, function(err) {
         t.ifError(err, 'success');

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -20,7 +20,7 @@ const opts = {
     templateBucket: 'my-template-bucket'
 };
 
-test('[commands.create] no overrides', async(t) => {
+test('[commands.create] no overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -37,7 +37,7 @@ test('[commands.create] no overrides', async(t) => {
     t.end();
 });
 
-test('[commands.create] with overrides', async(t) => {
+test('[commands.create] with overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -55,7 +55,7 @@ test('[commands.create] with overrides', async(t) => {
     t.end();
 });
 
-test('[commands.create] with template object', async(t) => {
+test('[commands.create] with template object', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -72,7 +72,7 @@ test('[commands.create] with template object', async(t) => {
     t.end();
 });
 
-test('[commands.update] no overrides', async(t) => {
+test('[commands.update] no overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -90,7 +90,7 @@ test('[commands.update] no overrides', async(t) => {
     t.end();
 });
 
-test('[commands.update] with overrides', async(t) => {
+test('[commands.update] with overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -107,7 +107,7 @@ test('[commands.update] with overrides', async(t) => {
     t.end();
 });
 
-test('[commands.update] with multiple overrides', async(t) => {
+test('[commands.update] with multiple overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -124,7 +124,7 @@ test('[commands.update] with multiple overrides', async(t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters', async(t) => {
+test('[commands.update] with overrides.skipConfirmParameters', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -142,7 +142,7 @@ test('[commands.update] with overrides.skipConfirmParameters', async(t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmTemplate', async(t) => {
+test('[commands.update] with overrides.skipConfirmTemplate', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -159,7 +159,7 @@ test('[commands.update] with overrides.skipConfirmTemplate', async(t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async(t) => {
+test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -176,7 +176,7 @@ test('[commands.update] with overrides.skipConfirmParameters and overrides.skipC
     t.end();
 });
 
-test('[commands.update] with template object', async(t) => {
+test('[commands.update] with template object', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -194,7 +194,7 @@ test('[commands.update] with template object', async(t) => {
     t.end();
 });
 
-test('[commands.delete] no overrides', async(t) => {
+test('[commands.delete] no overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -211,7 +211,7 @@ test('[commands.delete] no overrides', async(t) => {
     t.end();
 });
 
-test('[commands.delete] with overrides', async(t) => {
+test('[commands.delete] with overrides', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -228,7 +228,7 @@ test('[commands.delete] with overrides', async(t) => {
     t.end();
 });
 
-test('[commands.info] success w/o resources', async(t) => {
+test('[commands.info] success w/o resources', async (t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -249,7 +249,7 @@ test('[commands.info] success w/o resources', async(t) => {
     t.end();
 });
 
-test('[commands.info] success w/ resources', async(t) => {
+test('[commands.info] success w/ resources', async (t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -270,7 +270,7 @@ test('[commands.info] success w/ resources', async(t) => {
     t.end();
 });
 
-test('[commands.info] success w/o decrypt', async(t) => {
+test('[commands.info] success w/o decrypt', async (t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -291,13 +291,14 @@ test('[commands.info] success w/o decrypt', async(t) => {
     t.end();
 });
 
-test('[commands.info] success w/ decrypt', async(t) => {
+test('[commands.info] success w/ decrypt', async (t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
         t.ok(resources, 'lookup.info resources');
         t.ok(decrypt, 'lookup.info decrypt=true');
-        callback();
+
+        return Promise.resolve();
     });
 
     const cmd = new Commands(opts, true);
@@ -311,7 +312,7 @@ test('[commands.info] success w/ decrypt', async(t) => {
     t.end();
 });
 
-test('[commands.info] null provided as suffix', async(t) => {
+test('[commands.info] null provided as suffix', async (t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack', 'no trailing - on stack name');
         return Promise.resolve();
@@ -329,7 +330,7 @@ test('[commands.info] null provided as suffix', async(t) => {
     t.end();
 });
 
-test('[commands.save] kms-mode', async(t) => {
+test('[commands.save] kms-mode', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -345,7 +346,7 @@ test('[commands.save] kms-mode', async(t) => {
     t.end();
 });
 
-test('[commands.save] not kms-mode', async(t) => {
+test('[commands.save] not kms-mode', async (t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -404,361 +405,369 @@ test('[commands.commandContext] iterates through operations', async(t) => {
     t.end();
 });
 
-test('[commands.commandContext] callback with diffs', async(t) => {
-    const ops = [
-        commands.operations.confirmParameters,
-        commands.operations.confirmTemplate
-    ];
-
-    sinon.stub(prompt, 'confirm').callsFake(() => {
+test('[commands.commandContext] context.diffs', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake(() => {
         return Promise.resolve(true);
     });
 
-    const context = new CommandContext(opts, 'testing', ops, function(err, performed, diffs) {
-        t.ifError(err, 'success');
-        t.equal(performed, true, 'the requested command was performed');
-        t.deepEqual(diffs, {
+    try {
+        const ops = [
+            Operations.confirmParameters,
+            Operations.confirmTemplate
+        ];
+
+        const context = new CommandContext(opts, 'testing', ops);
+
+        context.oldParameters = { old: 'parameters' };
+        context.newParameters = { old: 'parameters', newones: 'too' };
+        context.oldTemplate = { old: 'template' };
+        context.newTemplate = { new: 'template' };
+
+        const performed = await context.run();
+
+        t.equals(performed, true);
+
+        t.deepEqual(context.diffs, {
             parameters: ' {\n\u001b[32m+  newones: "too"\u001b[39m\n }\n',
             template: '\x1B[90m {\n\x1B[39m\x1B[31m-"old": "template"\n\x1B[39m\x1B[32m+"new": "template"\n\x1B[39m\x1B[90m }\x1B[39m'
         }, 'callback provides diffs as 3rd arg');
-        prompt.confirm.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
 
-    context.oldParameters = { old: 'parameters' };
-    context.newParameters = { old: 'parameters', newones: 'too' };
-    context.oldTemplate = { old: 'template' };
-    context.newTemplate = { new: 'template' };
-
-    context.next();
+    Prompt.confirm.restore();
+    t.end();
 });
 
-test('[commands.commandContext] aborts', (t) => {
-    const ops = [
-        function(context) { context.abort(); }
-    ];
+test('[commands.commandContext] aborts', async (t) => {
 
-    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
-        t.ifError(err, 'success');
+    try {
+        const ops = [
+            () => { throw new Error('aborted') }
+        ];
+
+        const context = new CommandContext(opts, 'testing', ops);
+
+        const performed = await context.run();
+
         t.equal(performed, false, 'the requested command was not performed');
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
 
-    context.next();
+    t.end();
 });
 
-test('[commands.commandContext] aborts with error', (t) => {
-    const ops = [
-        function(context) { context.abort(new Error('failure')); }
-    ];
+test('[commands.commandContext] aborts with error', async (t) => {
+    try {
+        const ops = [
+            () => { throw new Error('failure'); }
+        ];
 
-    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
-        t.equal(err.message, 'failure', 'success');
-        t.equal(performed, false, 'the requested command was not performed');
-        t.end();
-    });
+        const context = new CommandContext(opts, 'testing', ops);
 
-    context.next();
+        await context.run();
+        t.fail();
+    } catch (err) {
+        t.equals(err.message, 'failure');
+    }
+
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] no template', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback();
+test('[commands.operations.updatePreamble] no template', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        return Promise.resolve();
     });
 
-    const context = Object.assign({}, basicContext, {
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof template.NotFoundError, 'expected error type');
-            t.equal(err.message, 'Could not load template: No template passed', 'expected error message');
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Template.NotFoundError, 'expected error type');
+        t.equal(err.message, 'Could not load template: No template passed', 'expected error message');
+    }
+
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] templatePath not found', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback();
+test('[commands.operations.updatePreamble] templatePath not found', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'template').callsFake((name, region) => {
+        return Promise.resolve();
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: '/tmp/invalid/path/nonono.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof template.NotFoundError, 'expected error type');
-            t.equal(err.message, 'Could not load template: /tmp/invalid/path/nonono.template.json does not exist', 'expected error message');
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = '/tmp/invalid/path/nonono.template.json',
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+
+    } catch (err) {
+        t.ok(err instanceof Template.NotFoundError, 'expected error type');
+        t.equal(err.message, 'Could not load template: /tmp/invalid/path/nonono.template.json does not exist', 'expected error message');
+    }
+
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] template invalid', (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback(new template.InvalidTemplateError('failure'));
+test('[commands.operations.updatePreamble] template invalid', async (t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        throw new Template.InvalidTemplateError('failure');
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        return Promise.resolve();
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof template.InvalidTemplateError, 'expected error type');
-            t.equal(err.message, 'Could not parse template: failure', 'expected error message');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
+        await Operations.updatePreamble(context);
 
-    commands.operations.updatePreamble(context);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Template.InvalidTemplateError, 'expected error type');
+        t.equal(err.message, 'Could not parse template: failure', 'expected error message');
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] stack not found for parameters', (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.updatePreamble] stack not found for parameters', async (t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new lookup.StackNotFoundError('failure'));
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        throw new Lookup.StackNotFoundError('failure');
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        return Promise.resolve();
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof lookup.StackNotFoundError, 'expected error type');
-            t.equal(err.message, 'Missing stack: failure', 'expected error message');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error type');
+        t.equal(err.message, 'Missing stack: failure', 'expected error message');
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack parameters', (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.updatePreamble] failure getting stack parameters', async (t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new lookup.CloudFormationError('failure'));
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        throw new Lookup.CloudFormationError('failure');
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        return Promise.resolve();
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof lookup.CloudFormationError, 'expected error type');
-            t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.CloudFormationError, 'expected error type');
+        t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
+
 });
 
-test('[commands.operations.updatePreamble] stack not found for template', (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.updatePreamble] stack not found for template', async (t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback(new lookup.StackNotFoundError('failure'));
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        throw new Lookup.StackNotFoundError('failure');
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof lookup.StackNotFoundError, 'expected error type');
-            t.equal(err.message, 'Missing stack: failure', 'expected error message');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error type');
+        t.equal(err.message, 'Missing stack: failure', 'expected error message');
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack template', (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.updatePreamble] failure getting stack template', async (t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback(new lookup.CloudFormationError('failure'));
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        throw new Lookup.CloudFormationError('failure');
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function(err) {
-            t.ok(err instanceof lookup.CloudFormationError, 'expected error type');
-            t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.CloudFormationError, 'expected error type');
+        t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] success', (t) => {
-    sinon.stub(template, 'read').callsFake(function(template, options, callback) {
+test('[commands.operations.updatePreamble] success', async (t) => {
+    sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
-        callback(null, { new: 'template' });
+        return Promise.resolve({ new: 'template' });
     });
 
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(null, { old: 'parameters' });
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve({ old: 'parameters' });
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback(null, { old: 'template' });
+    sinon.stub(Lookup, 'template').callsFake((name, region) => {
+        return Promise.resolve({ old: 'template' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: 'example.template.json',
-        overrides: { templateOptions: { template: 'options' } },
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.newTemplate, { new: 'template' }, 'sets context.newTemplate');
-            t.deepEqual(context.oldTemplate, { old: 'template' }, 'sets context.oldTemplate');
-            t.deepEqual(context.oldParameters, { old: 'parameters' }, 'sets context.oldParameters');
-            template.read.restore();
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        },
-        abort: function(err) {
-            t.ifError(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = 'example.template.json',
+        context.overrides = { templateOptions: { template: 'options' } },
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.deepEqual(context.newTemplate, { new: 'template' }, 'sets context.newTemplate');
+        t.deepEqual(context.oldTemplate, { old: 'template' }, 'sets context.oldTemplate');
+        t.deepEqual(context.oldParameters, { old: 'parameters' }, 'sets context.oldParameters');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Template.read.restore();
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.updatePreamble] success with template object', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(null, { old: 'parameters' });
+test('[commands.operations.updatePreamble] success with template object', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        return Promise.resolve({ old: 'parameters' });
     });
 
-    sinon.stub(lookup, 'template').callsFake(function(name, region, callback) {
-        callback(null, { old: 'template' });
+    sinon.stub(Lookup, 'template').callsFake(() => {
+        return Promise.resolve({ old: 'template' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        template: { arbitrary: 'template' },
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.newTemplate, { arbitrary: 'template' }, 'sets context.newTemplate');
-            t.deepEqual(context.oldTemplate, { old: 'template' }, 'sets context.oldTemplate');
-            t.deepEqual(context.oldParameters, { old: 'parameters' }, 'sets context.oldParameters');
-            lookup.parameters.restore();
-            lookup.template.restore();
-            t.end();
-        },
-        abort: function(err) {
-            t.ifError(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.template = { arbitrary: 'template' },
 
-    commands.operations.updatePreamble(context);
+        await Operations.updatePreamble(context);
+
+        t.deepEqual(context.newTemplate, { arbitrary: 'template' }, 'sets context.newTemplate');
+        t.deepEqual(context.oldTemplate, { old: 'template' }, 'sets context.oldTemplate');
+        t.deepEqual(context.oldParameters, { old: 'parameters' }, 'sets context.oldParameters');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Lookup.parameters.restore();
+    Lookup.template.restore();
+    t.end();
 });
 
-test('[commands.operations.getMasterConfig] success', (t) => {
-
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
-        callback(null, { old: 'fresh' });
+test('[commands.operations.getMasterConfig] success', async (t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
+        return Promise.resolve({ old: 'fresh' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        overrides: { masterConfig: 's3://chill.cfn.json' },
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.oldParameters, { old: 'secure:staleelats' }, 'sets context.oldParameters');
-            lookup.defaultConfiguration.restore();
-            t.end();
-        },
-        abort: function(err) {
-            if (err) t.error(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = { masterConfig: 's3://chill.cfn.json' },
+        context.oldParameters = { old: 'secure:staleelats' };
 
+        await Operations.getMasterConfig(context);
 
-    context.oldParameters = { old: 'secure:staleelats' };
-    commands.operations.getMasterConfig(context);
+        t.deepEqual(context.oldParameters, { old: 'secure:staleelats' }, 'sets context.oldParameters');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Lookup.defaultConfiguration.restore();
+    t.end();
 });
 
-test('[commands.operations.getMasterConfig] no-op', (t) => {
-
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
-        callback(null, { old: 'fresh' });
+test('[commands.operations.getMasterConfig] no-op', async (t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
+        return Promise.resolve({ old: 'fresh' });
     });
 
     const context = Object.assign({}, basicContext, {
@@ -766,7 +775,7 @@ test('[commands.operations.getMasterConfig] no-op', (t) => {
         next: function() {
             t.pass('calls next()');
             t.deepEqual(context.oldParameters, { old: 'stale' }, 'context.oldParameters stays the same');
-            lookup.defaultConfiguration.restore();
+            Lookup.defaultConfiguration.restore();
             t.end();
         },
         abort: function(err) {
@@ -778,9 +787,9 @@ test('[commands.operations.getMasterConfig] no-op', (t) => {
     commands.operations.getMasterConfig(context);
 });
 
-test('[commands.operations.getMasterConfig] failed', (t) => {
+test('[commands.operations.getMasterConfig] failed', async (t) => {
 
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
         callback(new Error(), {});
     });
 
@@ -790,7 +799,7 @@ test('[commands.operations.getMasterConfig] failed', (t) => {
             t.fail('should not call next');
         },
         abort: function() {
-            lookup.defaultConfiguration.restore();
+            Lookup.defaultConfiguration.restore();
             t.end();
         }
     });
@@ -799,9 +808,9 @@ test('[commands.operations.getMasterConfig] failed', (t) => {
     commands.operations.getMasterConfig(context);
 });
 
-test('[commands.operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', (t) => {
+test('[commands.operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', async (t) => {
 
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
         callback(null, { bingo: 'fresh' });
     });
 
@@ -810,7 +819,7 @@ test('[commands.operations.getMasterConfig] no matching oldParameters does not p
         next: function() {
             t.pass('calls next()');
             t.deepEqual(context.oldParameters, { old: 'stale' }, 'leaves context.oldParameters alone');
-            lookup.defaultConfiguration.restore();
+            Lookup.defaultConfiguration.restore();
             t.end();
         },
         abort: function(err) {
@@ -822,9 +831,9 @@ test('[commands.operations.getMasterConfig] no matching oldParameters does not p
     commands.operations.getMasterConfig(context);
 });
 
-test('[commands.operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', (t) => {
+test('[commands.operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', async (t) => {
 
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
         callback(null, { old: 'fresh' });
     });
 
@@ -834,7 +843,7 @@ test('[commands.operations.getMasterConfig] adding a newParameter that matches m
             t.pass('calls next()');
             t.deepEqual(context.oldParameters, { hello: 'goodbye' }, 'no matching keys between oldParameters and masterConfig, no oldParameters are replaced');
             t.deepEqual(context.newTemplate.Parameters, { old: 'special whale' }, 'newParameters are not replaced despite matching keys');
-            lookup.defaultConfiguration.restore();
+            Lookup.defaultConfiguration.restore();
             t.end();
         },
         abort: function(err) {
@@ -848,7 +857,7 @@ test('[commands.operations.getMasterConfig] adding a newParameter that matches m
     commands.operations.getMasterConfig(context);
 });
 
-test('[commands.operations.promptParameters] force-mode', (t) => {
+test('[commands.operations.promptParameters] force-mode', async (t) => {
     sinon.stub(template, 'questions').callsFake(function() {
         t.fail('should not build questions');
     });
@@ -869,7 +878,7 @@ test('[commands.operations.promptParameters] force-mode', (t) => {
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] not force-mode', (t) => {
+test('[commands.operations.promptParameters] not force-mode', async (t) => {
     const questions = { parameter: 'questions' };
     const answers = { parameter: 'answers' };
 
@@ -899,7 +908,7 @@ test('[commands.operations.promptParameters] not force-mode', (t) => {
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] with parameter and kms overrides', (t) => {
+test('[commands.operations.promptParameters] with parameter and kms overrides', async (t) => {
     sinon.stub(template, 'questions').callsFake(function(template, overrides) {
         t.deepEqual(overrides, { defaults: { old: 'overriden' }, kmsKeyId: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
         return { parameter: 'questions' };
@@ -925,7 +934,7 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] force-mode with no parameters in new template', (t) => {
+test('[commands.operations.promptParameters] force-mode with no parameters in new template', async (t) => {
     const context = Object.assign({}, basicContext, {
         newTemplate: { new: 'template' },
         overrides: { force: true },
@@ -939,7 +948,7 @@ test('[commands.operations.promptParameters] force-mode with no parameters in ne
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] reject overrides that are not in old or new template', (t) => {
+test('[commands.operations.promptParameters] reject overrides that are not in old or new template', async (t) => {
     sinon.stub(prompt, 'parameters').callsFake(() => {
         return Promise.resolve({ some: 'answers' });
     });
@@ -959,7 +968,7 @@ test('[commands.operations.promptParameters] reject overrides that are not in ol
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', (t) => {
+test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', async (t) => {
     const oldParameters = { old: 'parameters', the: 'answers' };
     const newParameters = { old: 'newvalue', the: 'answers' };
 
@@ -983,7 +992,7 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', (t) => {
+test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', async (t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
@@ -1007,7 +1016,7 @@ test('[commands.operations.promptParameters] changesetParameters does not set Us
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', (t) => {
+test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', async (t) => {
     const oldParameters = { beep: 'bop' };
     const newParameters = { beep: 'bop' };
 
@@ -1031,7 +1040,7 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', (t) => {
+test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', async (t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
@@ -1057,7 +1066,7 @@ test('[commands.operations.promptParameters] do not set UsePreviousValue when cr
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.confirmParameters] force-mode', (t) => {
+test('[commands.operations.confirmParameters] force-mode', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         oldParameters: { old: 'parameters' },
@@ -1071,7 +1080,7 @@ test('[commands.operations.confirmParameters] force-mode', (t) => {
     commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] no difference', (t) => {
+test('[commands.operations.confirmParameters] no difference', async (t) => {
     const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         newParameters: { old: 'parameters' },
@@ -1084,7 +1093,7 @@ test('[commands.operations.confirmParameters] no difference', (t) => {
     commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] preapproved', async(t) => {
+test('[commands.operations.confirmParameters] preapproved', async (t) => {
     sinon.stub(console, 'log');
 
     const context = Object.assign({}, basicContext, {
@@ -1105,7 +1114,7 @@ test('[commands.operations.confirmParameters] preapproved', async(t) => {
     await commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] rejected', async(t) => {
+test('[commands.operations.confirmParameters] rejected', async (t) => {
     t.plan(2);
 
     sinon.stub(prompt, 'confirm').callsFake((message) => {
@@ -1128,7 +1137,7 @@ test('[commands.operations.confirmParameters] rejected', async(t) => {
     }));
 });
 
-test('[commands.operations.confirmParameters] accepted', async(t) => {
+test('[commands.operations.confirmParameters] accepted', async (t) => {
     t.plan(2);
 
     sinon.stub(prompt, 'confirm').callsFake((message) => {
@@ -1151,7 +1160,7 @@ test('[commands.operations.confirmParameters] accepted', async(t) => {
     }));
 });
 
-test('[commands.operations.confirmTemplate] no difference', async(t) => {
+test('[commands.operations.confirmTemplate] no difference', async (t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { old: 'template' },
@@ -1164,7 +1173,7 @@ test('[commands.operations.confirmTemplate] no difference', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] undefined', async(t) => {
+test('[commands.operations.confirmTemplate] undefined', async (t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { Parameters: { old: undefined } },
         newTemplate: { Parameters: {} },
@@ -1177,7 +1186,7 @@ test('[commands.operations.confirmTemplate] undefined', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] force-mode', async(t) => {
+test('[commands.operations.confirmTemplate] force-mode', async (t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
@@ -1194,7 +1203,7 @@ test('[commands.operations.confirmTemplate] force-mode', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] preapproved', async(t) => {
+test('[commands.operations.confirmTemplate] preapproved', async (t) => {
     sinon.stub(console, 'log');
 
     const context = Object.assign({}, basicContext, {
@@ -1220,7 +1229,7 @@ test('[commands.operations.confirmTemplate] preapproved', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] rejected', async(t) => {
+test('[commands.operations.confirmTemplate] rejected', async (t) => {
     t.plan(2);
 
     sinon.stub(prompt, 'confirm').callsFake((message) => {
@@ -1249,7 +1258,7 @@ test('[commands.operations.confirmTemplate] rejected', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] accepted', async(t) => {
+test('[commands.operations.confirmTemplate] accepted', async (t) => {
     t.plan(2);
 
     sinon.stub(prompt, 'confirm').callsFake((message) => {
@@ -1273,7 +1282,7 @@ test('[commands.operations.confirmTemplate] accepted', async(t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', async(t) => {
+test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', async (t) => {
     t.plan(2);
 
     sinon.stub(prompt, 'confirm').callsFake((message) => {
@@ -1371,7 +1380,7 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] bucket not found', (t) => {
+test('[commands.operations.saveTemplate] bucket not found', async (t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function() {
@@ -1395,7 +1404,7 @@ test('[commands.operations.saveTemplate] bucket not found', (t) => {
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] failed to save template', (t) => {
+test('[commands.operations.saveTemplate] failed to save template', async (t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function() {
@@ -1419,7 +1428,7 @@ test('[commands.operations.saveTemplate] failed to save template', (t) => {
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] success', (t) => {
+test('[commands.operations.saveTemplate] success', async (t) => {
     const templateUrl = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function(bucket, region, suffix) {
@@ -1449,7 +1458,7 @@ test('[commands.operations.saveTemplate] success', (t) => {
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] invalid', (t) => {
+test('[commands.operations.validateTemplate] invalid', async (t) => {
     sinon.stub(actions, 'validate').callsFake(function(region, url, callback) {
         callback(new actions.CloudFormationError('failure'));
     });
@@ -1467,7 +1476,7 @@ test('[commands.operations.validateTemplate] invalid', (t) => {
     commands.operations.validateTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] valid', (t) => {
+test('[commands.operations.validateTemplate] valid', async (t) => {
     t.plan(3);
 
     sinon.stub(actions, 'validate').callsFake(function(region, url, callback) {
@@ -1490,7 +1499,7 @@ test('[commands.operations.validateTemplate] valid', (t) => {
     commands.operations.validateTemplate(context);
 });
 
-test('[commands.operations.beforeUpdateHook] no hook', (t) => {
+test('[commands.operations.beforeUpdateHook] no hook', async (t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1504,7 +1513,7 @@ test('[commands.operations.beforeUpdateHook] no hook', (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.validateParametersHook] no hook', (t) => {
+test('[commands.operations.validateParametersHook] no hook', async (t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1518,7 +1527,7 @@ test('[commands.operations.validateParametersHook] no hook', (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook error', (t) => {
+test('[commands.operations.validateParametersHook] hook error', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             validateParameters: function(context, callback) {
@@ -1537,7 +1546,7 @@ test('[commands.operations.validateParametersHook] hook error', (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook success', (t) => {
+test('[commands.operations.validateParametersHook] hook success', async (t) => {
     t.plan(2);
     const context = Object.assign({}, basicContext, {
         overrides: {
@@ -1557,7 +1566,7 @@ test('[commands.operations.validateParametersHook] hook success', (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook error', (t) => {
+test('[commands.operations.beforeUpdateHook] hook error', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             beforeUpdate: function(context, callback) {
@@ -1576,7 +1585,7 @@ test('[commands.operations.beforeUpdateHook] hook error', (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook success', (t) => {
+test('[commands.operations.beforeUpdateHook] hook success', async (t) => {
     t.plan(2);
 
     const context = Object.assign({}, basicContext, {
@@ -1597,7 +1606,7 @@ test('[commands.operations.beforeUpdateHook] hook success', (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.getChangeset] failure', (t) => {
+test('[commands.operations.getChangeset] failure', async (t) => {
     sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
         callback(new actions.CloudFormationError('failure'));
     });
@@ -1617,7 +1626,7 @@ test('[commands.operations.getChangeset] failure', (t) => {
     commands.operations.getChangeset(context);
 });
 
-test('[commands.operations.getChangeset] success', (t) => {
+test('[commands.operations.getChangeset] success', async (t) => {
     t.plan(8);
 
     const details = { changeset: 'details' };
@@ -1653,7 +1662,7 @@ test('[commands.operations.getChangeset] success', (t) => {
     commands.operations.getChangeset(context, 'UPDATE');
 });
 
-test('[commands.operations.getChangesetCreate] success', (t) => {
+test('[commands.operations.getChangesetCreate] success', async (t) => {
     t.plan(1);
 
     sinon.stub(commands.operations, 'getChangeset').callsFake(function(context, changeSetType) {
@@ -1671,7 +1680,7 @@ test('[commands.operations.getChangesetCreate] success', (t) => {
     commands.operations.getChangesetCreate(context);
 });
 
-test('[commands.operations.getChangesetUpdate] success', (t) => {
+test('[commands.operations.getChangesetUpdate] success', async (t) => {
     t.plan(1);
 
     sinon.stub(commands.operations, 'getChangeset').callsFake(function(context, changeSetType) {
@@ -1689,7 +1698,7 @@ test('[commands.operations.getChangesetUpdate] success', (t) => {
     commands.operations.getChangesetUpdate(context);
 });
 
-test('[commands.operations.confirmChangeset] force-mode', (t) => {
+test('[commands.operations.confirmChangeset] force-mode', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function() {
@@ -1704,7 +1713,7 @@ test('[commands.operations.confirmChangeset] force-mode', (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', (t) => {
+test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { skipConfirmParameters: true, skipConfirmTemplate: true },
         next: function() {
@@ -1719,7 +1728,7 @@ test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTem
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] rejected', (t) => {
+test('[commands.operations.confirmChangeset] rejected', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(defaultValue, false);
         return Promise.resolve(false);
@@ -1737,7 +1746,7 @@ test('[commands.operations.confirmChangeset] rejected', (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] acccepted', (t) => {
+test('[commands.operations.confirmChangeset] acccepted', async (t) => {
     t.plan(3);
 
     sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
@@ -1760,7 +1769,7 @@ test('[commands.operations.confirmChangeset] acccepted', (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] changeset formatting', (t) => {
+test('[commands.operations.confirmChangeset] changeset formatting', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Action  Name  Type  Replace\n------  ----  ----  -------\n\x1b[33mModify\x1b[39m  name  type  \x1b[31mtrue\x1b[39m   \n\x1b[32mAdd\x1b[39m     name  type  \x1b[32mfalse\x1b[39m  \n\x1b[31mRemove\x1b[39m  name  type  \x1b[32mfalse\x1b[39m  \n\nAccept changes and update the stack?', 'expected message (with colors)');
         t.equal(defaultValue, false);
@@ -1788,7 +1797,7 @@ test('[commands.operations.confirmChangeset] changeset formatting', (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.executeChangeSet] failure', (t) => {
+test('[commands.operations.executeChangeSet] failure', async (t) => {
     sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
         callback(new actions.CloudFormationError('failure'));
     });
@@ -1806,7 +1815,7 @@ test('[commands.operations.executeChangeSet] failure', (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] not executable', (t) => {
+test('[commands.operations.executeChangeSet] not executable', async (t) => {
     sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
         const err = new actions.ChangeSetNotExecutableError('failure');
         err.execution = 'OBSOLETE';
@@ -1827,7 +1836,7 @@ test('[commands.operations.executeChangeSet] not executable', (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] success', (t) => {
+test('[commands.operations.executeChangeSet] success', async (t) => {
     t.plan(4);
 
     sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
@@ -1849,8 +1858,8 @@ test('[commands.operations.executeChangeSet] success', (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.createPreamble] no template', (t) => {
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+test('[commands.operations.createPreamble] no template', async (t) => {
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
         callback();
     });
 
@@ -1858,7 +1867,7 @@ test('[commands.operations.createPreamble] no template', (t) => {
         abort: function(err) {
             t.ok(err instanceof template.NotFoundError, 'expected error type');
             t.equal(err.message, 'Could not load template: No template passed');
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1866,8 +1875,8 @@ test('[commands.operations.createPreamble] no template', (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template not found', (t) => {
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+test('[commands.operations.createPreamble] template not found', async (t) => {
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
         callback();
     });
 
@@ -1876,7 +1885,7 @@ test('[commands.operations.createPreamble] template not found', (t) => {
         abort: function(err) {
             t.ok(err instanceof template.NotFoundError, 'expected error type');
             t.equal(err.message, 'Could not load template: /tmp/invalid/path/nonono.template.json does not exist', 'expected error message');
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1884,12 +1893,12 @@ test('[commands.operations.createPreamble] template not found', (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template invalid', (t) => {
+test('[commands.operations.createPreamble] template invalid', async (t) => {
     sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
         callback(new template.InvalidTemplateError('failure'));
     });
 
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
         callback();
     });
 
@@ -1899,7 +1908,7 @@ test('[commands.operations.createPreamble] template invalid', (t) => {
             t.ok(err instanceof template.InvalidTemplateError, 'expected error type');
             t.equal(err.message, 'Could not parse template: failure');
             template.read.restore();
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1907,22 +1916,22 @@ test('[commands.operations.createPreamble] template invalid', (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] config bucket not found', (t) => {
+test('[commands.operations.createPreamble] config bucket not found', async (t) => {
     sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
         callback();
     });
 
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback(new lookup.BucketNotFoundError('failure'));
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+        callback(new Lookup.BucketNotFoundError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
-            t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
+            t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find config bucket: failure');
             template.read.restore();
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1930,22 +1939,22 @@ test('[commands.operations.createPreamble] config bucket not found', (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] failed to read configurations', (t) => {
+test('[commands.operations.createPreamble] failed to read configurations', async (t) => {
     sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
         callback();
     });
 
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback(new lookup.S3Error('failure'));
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+        callback(new Lookup.S3Error('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
-            t.ok(err instanceof lookup.S3Error, 'expected error type');
+            t.ok(err instanceof Lookup.S3Error, 'expected error type');
             t.equal(err.message, 'Could not load saved configurations: failure');
             template.read.restore();
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1953,14 +1962,14 @@ test('[commands.operations.createPreamble] failed to read configurations', (t) =
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success', (t) => {
+test('[commands.operations.createPreamble] success', async (t) => {
     sinon.stub(template, 'read').callsFake(function(template, options, callback) {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
         callback(null, { new: 'template' });
     });
 
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
         callback(null, ['config']);
@@ -1975,7 +1984,7 @@ test('[commands.operations.createPreamble] success', (t) => {
             t.deepEqual(context.configNames, ['config'], 'set context.configNames');
             t.ok(context.create, 'context.create is set to true');
             template.read.restore();
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -1983,14 +1992,14 @@ test('[commands.operations.createPreamble] success', (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success with template object', (t) => {
+test('[commands.operations.createPreamble] success with template object', async (t) => {
     sinon.stub(template, 'read').callsFake(function(template, options, callback) {
         t.equal(template, path.resolve(context.template), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
         callback(null, context.template);
     });
 
-    sinon.stub(lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
         callback(null, ['config']);
@@ -2005,7 +2014,7 @@ test('[commands.operations.createPreamble] success with template object', (t) =>
             t.deepEqual(context.configNames, ['config'], 'set context.configNames');
             t.ok(context.create, 'context.create is set to true');
             template.read.restore();
-            lookup.configurations.restore();
+            Lookup.configurations.restore();
             t.end();
         }
     });
@@ -2013,7 +2022,7 @@ test('[commands.operations.createPreamble] success with template object', (t) =>
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.selectConfig] force-mode', (t) => {
+test('[commands.operations.selectConfig] force-mode', async (t) => {
     sinon.stub(prompt, 'configuration').callsFake(function(configs, callback) {
         t.fail('should not prompt');
         callback(new Error('failure'));
@@ -2032,7 +2041,7 @@ test('[commands.operations.selectConfig] force-mode', (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] new config', (t) => {
+test('[commands.operations.selectConfig] new config', async (t) => {
     sinon.stub(prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('New configuration');
@@ -2051,7 +2060,7 @@ test('[commands.operations.selectConfig] new config', (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] saved config', (t) => {
+test('[commands.operations.selectConfig] saved config', async (t) => {
     sinon.stub(prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('config');
@@ -2070,7 +2079,7 @@ test('[commands.operations.selectConfig] saved config', (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, no default', (t) => {
+test('[commands.operations.loadConfig] no saved config, no default', async (t) => {
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
@@ -2082,8 +2091,8 @@ test('[commands.operations.loadConfig] no saved config, no default', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, has default', (t) => {
-    sinon.stub(lookup, 'defaultConfiguration').callsFake(function(s3url, callback) {
+test('[commands.operations.loadConfig] no saved config, has default', async (t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3url, callback) {
         t.equal(s3url, 's3://my-bucket/my-default.cfn.json', 'requested correct configuration');
         callback(null, { default: 'configuration' });
     });
@@ -2093,7 +2102,7 @@ test('[commands.operations.loadConfig] no saved config, has default', (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.oldParameters, { default: 'configuration' }, 'sets context.oldParameters');
-            lookup.defaultConfiguration.restore();
+            Lookup.defaultConfiguration.restore();
             t.end();
         }
     });
@@ -2101,17 +2110,17 @@ test('[commands.operations.loadConfig] no saved config, has default', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] bucket not found', (t) => {
-    sinon.stub(lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new lookup.BucketNotFoundError('failure'));
+test('[commands.operations.loadConfig] bucket not found', async (t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+        callback(new Lookup.BucketNotFoundError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
-            t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
+            t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find config bucket: failure', 'expected error message');
-            lookup.configuration.restore();
+            Lookup.configuration.restore();
             t.end();
         }
     });
@@ -2119,17 +2128,17 @@ test('[commands.operations.loadConfig] bucket not found', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] config not found', (t) => {
-    sinon.stub(lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new lookup.ConfigurationNotFoundError('failure'));
+test('[commands.operations.loadConfig] config not found', async (t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+        callback(new Lookup.ConfigurationNotFoundError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
-            t.ok(err instanceof lookup.ConfigurationNotFoundError, 'expected error type');
+            t.ok(err instanceof Lookup.ConfigurationNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find saved configuration: failure', 'expected error message');
-            lookup.configuration.restore();
+            Lookup.configuration.restore();
             t.end();
         }
     });
@@ -2137,17 +2146,17 @@ test('[commands.operations.loadConfig] config not found', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] invalid config', (t) => {
-    sinon.stub(lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new lookup.InvalidConfigurationError('failure'));
+test('[commands.operations.loadConfig] invalid config', async (t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+        callback(new Lookup.InvalidConfigurationError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
-            t.ok(err instanceof lookup.InvalidConfigurationError, 'expected error type');
+            t.ok(err instanceof Lookup.InvalidConfigurationError, 'expected error type');
             t.equal(err.message, 'Saved configuration error: failure', 'expected error message');
-            lookup.configuration.restore();
+            Lookup.configuration.restore();
             t.end();
         }
     });
@@ -2155,17 +2164,17 @@ test('[commands.operations.loadConfig] invalid config', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] failed to load config', (t) => {
-    sinon.stub(lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new lookup.S3Error('failure'));
+test('[commands.operations.loadConfig] failed to load config', async (t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+        callback(new Lookup.S3Error('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
-            t.ok(err instanceof lookup.S3Error, 'expected error type');
+            t.ok(err instanceof Lookup.S3Error, 'expected error type');
             t.equal(err.message, 'Failed to read saved configuration: failure', 'expected error message');
-            lookup.configuration.restore();
+            Lookup.configuration.restore();
             t.end();
         }
     });
@@ -2173,8 +2182,8 @@ test('[commands.operations.loadConfig] failed to load config', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] success', (t) => {
-    sinon.stub(lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+test('[commands.operations.loadConfig] success', async (t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
         t.equal(name, context.baseName, 'expected stack name');
         t.equal(bucket, context.configBucket, 'expected config bucket');
         t.equal(config, context.configName, 'expected config name');
@@ -2186,7 +2195,7 @@ test('[commands.operations.loadConfig] success', (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.oldParameters, { saved: 'configuration' }, 'set context.oldParameters');
-            lookup.configuration.restore();
+            Lookup.configuration.restore();
             t.end();
         }
     });
@@ -2194,7 +2203,7 @@ test('[commands.operations.loadConfig] success', (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.confirmCreate] force-mode', (t) => {
+test('[commands.operations.confirmCreate] force-mode', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake(function(message, callback) {
         t.fail('should not prompt');
         callback(new Error('failure'));
@@ -2212,7 +2221,7 @@ test('[commands.operations.confirmCreate] force-mode', (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] reject', (t) => {
+test('[commands.operations.confirmCreate] reject', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
@@ -2229,7 +2238,7 @@ test('[commands.operations.confirmCreate] reject', (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] accept', (t) => {
+test('[commands.operations.confirmCreate] accept', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to create the stack?', 'expected message');
         return Promise.resolve(true);
@@ -2247,7 +2256,7 @@ test('[commands.operations.confirmCreate] accept', (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmDelete] force-mode', (t) => {
+test('[commands.operations.confirmDelete] force-mode', async (t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
@@ -2259,7 +2268,7 @@ test('[commands.operations.confirmDelete] force-mode', (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] reject', (t) => {
+test('[commands.operations.confirmDelete] reject', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?');
         t.equal(defaultValue, false);
@@ -2277,7 +2286,7 @@ test('[commands.operations.confirmDelete] reject', (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] accept', (t) => {
+test('[commands.operations.confirmDelete] accept', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?', 'expected message');
         t.equal(defaultValue, false);
@@ -2295,7 +2304,7 @@ test('[commands.operations.confirmDelete] accept', (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.deleteStack] failure', (t) => {
+test('[commands.operations.deleteStack] failure', async (t) => {
     sinon.stub(actions, 'delete').callsFake(function(name, region, callback) {
         callback(new actions.CloudFormationError('failure'));
     });
@@ -2312,7 +2321,7 @@ test('[commands.operations.deleteStack] failure', (t) => {
     commands.operations.deleteStack(context);
 });
 
-test('[commands.operations.deleteStack] success', (t) => {
+test('[commands.operations.deleteStack] success', async (t) => {
     sinon.stub(actions, 'delete').callsFake(function(name, region, callback) {
         t.equal(name, context.stackName, 'deleted expected stack');
         t.equal(region, context.stackRegion, 'deleted in expected region');
@@ -2330,7 +2339,7 @@ test('[commands.operations.deleteStack] success', (t) => {
     commands.operations.deleteStack(context);
 });
 
-test('[commands.operations.monitorStack] failure', (t) => {
+test('[commands.operations.monitorStack] failure', async (t) => {
     sinon.stub(actions, 'monitor').callsFake(function(name, region, callback) {
         callback(new actions.CloudFormationError('failure'));
     });
@@ -2346,7 +2355,7 @@ test('[commands.operations.monitorStack] failure', (t) => {
     commands.operations.monitorStack(context);
 });
 
-test('[commands.operations.monitorStack] success', (t) => {
+test('[commands.operations.monitorStack] success', async (t) => {
     sinon.stub(actions, 'monitor').callsFake(function(name, region, callback) {
         t.equal(name, context.stackName, 'monitor expected stack');
         t.equal(region, context.stackRegion, 'monitor in expected region');
@@ -2364,16 +2373,16 @@ test('[commands.operations.monitorStack] success', (t) => {
     commands.operations.monitorStack(context);
 });
 
-test('[commands.operations.getOldParameters] missing stack', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new lookup.StackNotFoundError('failure'));
+test('[commands.operations.getOldParameters] missing stack', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
+        callback(new Lookup.StackNotFoundError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof lookup.StackNotFoundError, 'expected error type');
+            t.ok(err instanceof Lookup.StackNotFoundError, 'expected error type');
             t.equal(err.message, 'Missing stack: failure', 'expected error message');
-            lookup.parameters.restore();
+            Lookup.parameters.restore();
             t.end();
         }
     });
@@ -2381,16 +2390,16 @@ test('[commands.operations.getOldParameters] missing stack', (t) => {
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] failed to lookup stack', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new lookup.CloudFormationError('failure'));
+test('[commands.operations.getOldParameters] failed to lookup stack', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
+        callback(new Lookup.CloudFormationError('failure'));
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof lookup.CloudFormationError, 'expected error type');
+            t.ok(err instanceof Lookup.CloudFormationError, 'expected error type');
             t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
-            lookup.parameters.restore();
+            Lookup.parameters.restore();
             t.end();
         }
     });
@@ -2398,8 +2407,8 @@ test('[commands.operations.getOldParameters] failed to lookup stack', (t) => {
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] success', (t) => {
-    sinon.stub(lookup, 'parameters').callsFake(function(name, region, callback) {
+test('[commands.operations.getOldParameters] success', async (t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
         t.equal(name, context.stackName, 'lookup expected stack');
         t.equal(region, context.stackRegion, 'lookup in expected region');
         callback(null, { old: 'parameters' });
@@ -2409,7 +2418,7 @@ test('[commands.operations.getOldParameters] success', (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.oldParameters, { old: 'parameters' }, 'set context.oldParameters');
-            lookup.parameters.restore();
+            Lookup.parameters.restore();
             t.end();
         }
     });
@@ -2417,7 +2426,7 @@ test('[commands.operations.getOldParameters] success', (t) => {
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.promptSaveConfig]', (t) => {
+test('[commands.operations.promptSaveConfig]', async (t) => {
     sinon.stub(prompt, 'input').callsFake((message, def) => {
         t.equal(message, 'Name for saved configuration:', 'expected prompt');
         t.equal(def, context.suffix, 'expected default value');
@@ -2437,7 +2446,7 @@ test('[commands.operations.promptSaveConfig]', (t) => {
     commands.operations.promptSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] reject', (t) => {
+test('[commands.operations.confirmSaveConfig] reject', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
@@ -2454,7 +2463,7 @@ test('[commands.operations.confirmSaveConfig] reject', (t) => {
     commands.operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] accept', (t) => {
+test('[commands.operations.confirmSaveConfig] accept', async (t) => {
     sinon.stub(prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to save this configuration as "hello"?', 'expected message');
         return Promise.resolve(true);
@@ -2473,7 +2482,7 @@ test('[commands.operations.confirmSaveConfig] accept', (t) => {
     commands.operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.saveConfig] bucket not found', (t) => {
+test('[commands.operations.saveConfig] bucket not found', async (t) => {
     sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
         callback(new actions.BucketNotFoundError('failure'));
     });
@@ -2492,7 +2501,7 @@ test('[commands.operations.saveConfig] bucket not found', (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] failure', (t) => {
+test('[commands.operations.saveConfig] failure', async (t) => {
     sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
         callback(new actions.S3Error('failure'));
     });
@@ -2511,7 +2520,7 @@ test('[commands.operations.saveConfig] failure', (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] success', (t) => {
+test('[commands.operations.saveConfig] success', async (t) => {
     sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
         t.equal(baseName, context.baseName, 'save under correct stack name');
         t.equal(stackName, context.stackName, 'save under correct stack name');
@@ -2535,7 +2544,7 @@ test('[commands.operations.saveConfig] success', (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.mergeMetadata]', (t) => {
+test('[commands.operations.mergeMetadata]', async (t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
@@ -2554,7 +2563,7 @@ test('[commands.operations.mergeMetadata]', (t) => {
     commands.operations.mergeMetadata(context);
 });
 
-test('[commands.operations.mergeMetadata] error', (t) => {
+test('[commands.operations.mergeMetadata] error', async (t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template', Metadata: { LastDeploy: 'jane' } },

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -16,7 +16,7 @@ const opts = {
     templateBucket: 'my-template-bucket'
 };
 
-var basicContext = commands.commandContext(opts, 'testing', [], function() {});
+const basicContext = commands.commandContext(opts, 'testing', [], function() {});
 
 test('[commands.create] no overrides', (t) => {
     function whenDone() {}
@@ -28,7 +28,7 @@ test('[commands.create] no overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -53,7 +53,7 @@ test('[commands.create] with overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -79,7 +79,7 @@ test('[commands.create] with template object', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.deepEqual(context.template, { arbitrary: 'template' }, 'set context.template');
@@ -104,7 +104,7 @@ test('[commands.update] no overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -129,7 +129,7 @@ test('[commands.update] with overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -153,7 +153,7 @@ test('[commands.update] with multiple overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -178,7 +178,7 @@ test('[commands.update] with overrides.skipConfirmParameters', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -203,7 +203,7 @@ test('[commands.update] with overrides.skipConfirmTemplate', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -228,7 +228,7 @@ test('[commands.update] with overrides.skipConfirmParameters and overrides.skipC
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.template, 'templatePath', 'set context.template');
@@ -254,7 +254,7 @@ test('[commands.update] with template object', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.deepEqual(context.template, { arbitrary: 'template' }, 'set context.template');
@@ -279,7 +279,7 @@ test('[commands.delete] no overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.deepEqual(context.overrides, {}, 'sets empty overrides');
@@ -303,7 +303,7 @@ test('[commands.delete] with overrides', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.deepEqual(context.overrides, { force: true }, 'sets empty overrides');
@@ -404,7 +404,7 @@ test('[commands.save] kms-mode', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.kms, true, 'sets context.kms');
@@ -428,7 +428,7 @@ test('[commands.save] not kms-mode', (t) => {
         t.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
         t.equal(callback, whenDone, 'instantiate context with final callback function');
 
-        var context = Object.assign({}, basicContext, {
+        const context = Object.assign({}, basicContext, {
             next: function() {
                 t.pass('called next to begin process');
                 t.equal(context.kms, false, 'sets context.kms');
@@ -444,7 +444,7 @@ test('[commands.save] not kms-mode', (t) => {
 });
 
 test('[commands.commandContext] sets context', (t) => {
-    var context = commands.commandContext(opts, 'testing', opts, function() {});
+    const context = commands.commandContext(opts, 'testing', opts, function() {});
     t.equal(context.baseName, opts.name, 'sets baseName');
     t.equal(context.suffix, 'testing', 'sets suffix');
     t.equal(context.stackName, opts.name + '-testing', 'sets stackName');
@@ -459,14 +459,14 @@ test('[commands.commandContext] sets context', (t) => {
 });
 
 test('[commands.commandContext] handles null suffix', (t) => {
-    var context = commands.commandContext(opts, null, opts, function() {});
+    const context = commands.commandContext(opts, null, opts, function() {});
     t.equal(context.stackName, opts.name, 'sets stackName without trailing -');
     t.end();
 });
 
 test('[commands.commandContext] iterates through operations', (t) => {
-    var i = 0;
-    var ops = [
+    const i = 0;
+    const ops = [
         function(context) {
             t.equal(i, 0, 'called first function');
             i++;
@@ -479,7 +479,7 @@ test('[commands.commandContext] iterates through operations', (t) => {
         }
     ];
 
-    var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
+    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
         t.ifError(err, 'success');
         t.equal(performed, true, 'the requested command was performed');
         t.end();
@@ -518,11 +518,11 @@ test('[commands.commandContext] callback with diffs', (t) => {
 });
 
 test('[commands.commandContext] aborts', (t) => {
-    var ops = [
+    const ops = [
         function(context) { context.abort(); }
     ];
 
-    var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
+    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
         t.ifError(err, 'success');
         t.equal(performed, false, 'the requested command was not performed');
         t.end();
@@ -532,11 +532,11 @@ test('[commands.commandContext] aborts', (t) => {
 });
 
 test('[commands.commandContext] aborts with error', (t) => {
-    var ops = [
+    const ops = [
         function(context) { context.abort(new Error('failure')); }
     ];
 
-    var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
+    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
         t.equal(err.message, 'failure', 'success');
         t.equal(performed, false, 'the requested command was not performed');
         t.end();
@@ -554,7 +554,7 @@ test('[commands.operations.updatePreamble] no template', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function() {
             t.fail('should not call next');
         },
@@ -579,7 +579,7 @@ test('[commands.operations.updatePreamble] templatePath not found', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: '/tmp/invalid/path/nonono.template.json',
         next: function() {
             t.fail('should not call next');
@@ -609,7 +609,7 @@ test('[commands.operations.updatePreamble] template invalid', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         next: function() {
             t.fail('should not call next');
@@ -640,7 +640,7 @@ test('[commands.operations.updatePreamble] stack not found for parameters', (t) 
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         next: function() {
             t.fail('should not call next');
@@ -671,7 +671,7 @@ test('[commands.operations.updatePreamble] failure getting stack parameters', (t
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         next: function() {
             t.fail('should not call next');
@@ -702,7 +702,7 @@ test('[commands.operations.updatePreamble] stack not found for template', (t) =>
         callback(new lookup.StackNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         next: function() {
             t.fail('should not call next');
@@ -733,7 +733,7 @@ test('[commands.operations.updatePreamble] failure getting stack template', (t) 
         callback(new lookup.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         next: function() {
             t.fail('should not call next');
@@ -766,7 +766,7 @@ test('[commands.operations.updatePreamble] success', (t) => {
         callback(null, { old: 'template' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         overrides: { templateOptions: { template: 'options' } },
         next: function() {
@@ -796,7 +796,7 @@ test('[commands.operations.updatePreamble] success with template object', (t) =>
         callback(null, { old: 'template' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: { arbitrary: 'template' },
         next: function() {
             t.pass('calls next()');
@@ -821,7 +821,7 @@ test('[commands.operations.getMasterConfig] success', (t) => {
         callback(null, { old: 'fresh' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { masterConfig: 's3://chill.cfn.json' },
         next: function() {
             t.pass('calls next()');
@@ -845,7 +845,7 @@ test('[commands.operations.getMasterConfig] no-op', (t) => {
         callback(null, { old: 'fresh' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: {},
         next: function() {
             t.pass('calls next()');
@@ -868,7 +868,7 @@ test('[commands.operations.getMasterConfig] failed', (t) => {
         callback(new Error(), {});
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { masterConfig: 's3://unchill.cfn.json' },
         next: function() {
             t.fail('should not call next');
@@ -889,7 +889,7 @@ test('[commands.operations.getMasterConfig] no matching oldParameters does not p
         callback(null, { bingo: 'fresh' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { masterConfig: 's3://chill.cfn.json' },
         next: function() {
             t.pass('calls next()');
@@ -912,7 +912,7 @@ test('[commands.operations.getMasterConfig] adding a newParameter that matches m
         callback(null, { old: 'fresh' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { masterConfig: 's3://chill.cfn.json' },
         next: function() {
             t.pass('calls next()');
@@ -937,7 +937,7 @@ test('[commands.operations.promptParameters] force-mode', (t) => {
         t.fail('should not build questions');
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newTemplate: { Parameters: { old: {}, new: {} } },
         oldParameters: { old: 'parameters', extra: 'value' },
         overrides: { force: true },
@@ -954,8 +954,8 @@ test('[commands.operations.promptParameters] force-mode', (t) => {
 });
 
 test('[commands.operations.promptParameters] not force-mode', (t) => {
-    var questions = { parameter: 'questions' };
-    var answers = { parameter: 'answers' };
+    const questions = { parameter: 'questions' };
+    const answers = { parameter: 'answers' };
 
     sinon.stub(template, 'questions').callsFake(function(template, overrides) {
         t.deepEqual(template, { new: 'template' }, 'builds questions for new template');
@@ -968,7 +968,7 @@ test('[commands.operations.promptParameters] not force-mode', (t) => {
         return Promise.resolve(answers);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newTemplate: { new: 'template' },
         oldParameters: { old: 'parameters' },
         next: function(err) {
@@ -993,7 +993,7 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
         return Promise.resolve({ the: 'answers' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         oldParameters: { old: 'parameters' },
@@ -1010,7 +1010,7 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
 });
 
 test('[commands.operations.promptParameters] force-mode with no parameters in new template', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newTemplate: { new: 'template' },
         overrides: { force: true },
         next: function(err) {
@@ -1028,7 +1028,7 @@ test('[commands.operations.promptParameters] reject overrides that are not in ol
         return Promise.resolve({ some: 'answers' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newTemplate: { Parameters: { Name: {} } },
         oldParameters: { Name: 'name', Age: 'age' },
         overrides: { parameters: { Name: 'overriden', Born: 'ignored' } },
@@ -1044,14 +1044,14 @@ test('[commands.operations.promptParameters] reject overrides that are not in ol
 });
 
 test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', (t) => {
-    var oldParameters = { old: 'parameters', the: 'answers' };
-    var newParameters = { old: 'newvalue', the: 'answers' };
+    const oldParameters = { old: 'parameters', the: 'answers' };
+    const newParameters = { old: 'newvalue', the: 'answers' };
 
     sinon.stub(prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         oldParameters: oldParameters,
@@ -1068,14 +1068,14 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
 });
 
 test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', (t) => {
-    var oldParameters = { beep: 'boop' };
-    var newParameters = { beep: 'boop' };
+    const oldParameters = { beep: 'boop' };
+    const newParameters = { beep: 'boop' };
 
     sinon.stub(prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         oldParameters: oldParameters,
@@ -1092,14 +1092,14 @@ test('[commands.operations.promptParameters] changesetParameters does not set Us
 });
 
 test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', (t) => {
-    var oldParameters = { beep: 'bop' };
-    var newParameters = { beep: 'bop' };
+    const oldParameters = { beep: 'bop' };
+    const newParameters = { beep: 'bop' };
 
     sinon.stub(prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         oldParameters: oldParameters,
@@ -1116,14 +1116,14 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
 });
 
 test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', (t) => {
-    var oldParameters = { beep: 'boop' };
-    var newParameters = { beep: 'boop' };
+    const oldParameters = { beep: 'boop' };
+    const newParameters = { beep: 'boop' };
 
     sinon.stub(prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         create: true,
@@ -1142,7 +1142,7 @@ test('[commands.operations.promptParameters] do not set UsePreviousValue when cr
 });
 
 test('[commands.operations.confirmParameters] force-mode', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         oldParameters: { old: 'parameters' },
         newParameters: { old: 'parameters' },
@@ -1156,7 +1156,7 @@ test('[commands.operations.confirmParameters] force-mode', (t) => {
 });
 
 test('[commands.operations.confirmParameters] no difference', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         newParameters: { old: 'parameters' },
         next: function() {
@@ -1236,7 +1236,7 @@ test('[commands.operations.confirmParameters] accepted', async(t) => {
 });
 
 test('[commands.operations.confirmTemplate] no difference', async(t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { old: 'template' },
         next: function() {
@@ -1249,7 +1249,7 @@ test('[commands.operations.confirmTemplate] no difference', async(t) => {
 });
 
 test('[commands.operations.confirmTemplate] undefined', async(t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: { Parameters: { old: undefined } },
         newTemplate: { Parameters: {} },
         next: function() {
@@ -1262,7 +1262,7 @@ test('[commands.operations.confirmTemplate] undefined', async(t) => {
 });
 
 test('[commands.operations.confirmTemplate] force-mode', async(t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
         overrides: { force: true },
@@ -1317,7 +1317,7 @@ test('[commands.operations.confirmTemplate] rejected', async(t) => {
 
     basicContext.overrides = {}; // some previous test has mutated this
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
         next: function() {
@@ -1341,7 +1341,7 @@ test('[commands.operations.confirmTemplate] accepted', async(t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
         next: function(err) {
@@ -1365,7 +1365,7 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldTemplate: {
             old: 'template',
             a: 'lines',
@@ -1456,7 +1456,7 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
 });
 
 test('[commands.operations.saveTemplate] bucket not found', (t) => {
-    var url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
+    const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function() {
         return url;
@@ -1466,7 +1466,7 @@ test('[commands.operations.saveTemplate] bucket not found', (t) => {
         callback(new actions.BucketNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof actions.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find template bucket: failure', 'expected error message');
@@ -1480,7 +1480,7 @@ test('[commands.operations.saveTemplate] bucket not found', (t) => {
 });
 
 test('[commands.operations.saveTemplate] failed to save template', (t) => {
-    var url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
+    const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function() {
         return url;
@@ -1490,7 +1490,7 @@ test('[commands.operations.saveTemplate] failed to save template', (t) => {
         callback(new actions.S3Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof actions.S3Error, 'expected error type');
             t.equal(err.message, 'Failed to save template: failure', 'expected error message');
@@ -1504,7 +1504,7 @@ test('[commands.operations.saveTemplate] failed to save template', (t) => {
 });
 
 test('[commands.operations.saveTemplate] success', (t) => {
-    var templateUrl = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
+    const templateUrl = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(actions, 'templateUrl').callsFake(function(bucket, region, suffix) {
         t.equal(bucket, context.templateBucket, 'template url in proper bucket');
@@ -1519,7 +1519,7 @@ test('[commands.operations.saveTemplate] success', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newTemplate: { new: 'template' },
         next: function(err) {
             t.ifError(err, 'success');
@@ -1538,7 +1538,7 @@ test('[commands.operations.validateTemplate] invalid', (t) => {
         callback(new actions.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         templateUrl: 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json',
         abort: function(err) {
             t.ok(err instanceof actions.CloudFormationError, 'correct error type');
@@ -1560,7 +1560,7 @@ test('[commands.operations.validateTemplate] valid', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         templateUrl: 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json',
         abort: function() {
             t.fail('failed');
@@ -1575,7 +1575,7 @@ test('[commands.operations.validateTemplate] valid', (t) => {
 });
 
 test('[commands.operations.beforeUpdateHook] no hook', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
         },
@@ -1589,7 +1589,7 @@ test('[commands.operations.beforeUpdateHook] no hook', (t) => {
 });
 
 test('[commands.operations.validateParametersHook] no hook', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
         },
@@ -1603,7 +1603,7 @@ test('[commands.operations.validateParametersHook] no hook', (t) => {
 });
 
 test('[commands.operations.validateParametersHook] hook error', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: {
             validateParameters: function(context, callback) {
                 callback(new Error('failure'));
@@ -1623,7 +1623,7 @@ test('[commands.operations.validateParametersHook] hook error', (t) => {
 
 test('[commands.operations.validateParametersHook] hook success', (t) => {
     t.plan(2);
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: {
             validateParameters: function(arg, callback) {
                 t.deepEqual(arg, context, 'provided hook with runtime context');
@@ -1642,7 +1642,7 @@ test('[commands.operations.validateParametersHook] hook success', (t) => {
 });
 
 test('[commands.operations.beforeUpdateHook] hook error', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: {
             beforeUpdate: function(context, callback) {
                 callback(new Error('failure'));
@@ -1663,7 +1663,7 @@ test('[commands.operations.beforeUpdateHook] hook error', (t) => {
 test('[commands.operations.beforeUpdateHook] hook success', (t) => {
     t.plan(2);
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: {
             beforeUpdate: function(arg, callback) {
                 t.deepEqual(arg, context, 'provided hook with runtime context');
@@ -1686,7 +1686,7 @@ test('[commands.operations.getChangeset] failure', (t) => {
         callback(new actions.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof actions.CloudFormationError, 'correct error type');
             t.equal(err.message, 'Failed to generate changeset: failure', 'expected error message');
@@ -1704,7 +1704,7 @@ test('[commands.operations.getChangeset] failure', (t) => {
 test('[commands.operations.getChangeset] success', (t) => {
     t.plan(8);
 
-    var details = { changeset: 'details' };
+    const details = { changeset: 'details' };
 
     sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
         t.equal(name, context.stackName, 'changeset for correct stack');
@@ -1716,7 +1716,7 @@ test('[commands.operations.getChangeset] success', (t) => {
         callback(null, details);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackName: 'my-stack-testing',
         stackRegion: 'us-east-1',
         newParameters: { new: 'parameters' },
@@ -1774,7 +1774,7 @@ test('[commands.operations.getChangesetUpdate] success', (t) => {
 });
 
 test('[commands.operations.confirmChangeset] force-mode', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function() {
             t.pass('accepted with no prompt');
@@ -1789,7 +1789,7 @@ test('[commands.operations.confirmChangeset] force-mode', (t) => {
 });
 
 test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { skipConfirmParameters: true, skipConfirmTemplate: true },
         next: function() {
             t.pass('accepted with no prompt');
@@ -1809,7 +1809,7 @@ test('[commands.operations.confirmChangeset] rejected', (t) => {
         return Promise.resolve(false);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: { changes: [] },
         abort: function(err) {
             t.ifError(err, 'aborted');
@@ -1830,7 +1830,7 @@ test('[commands.operations.confirmChangeset] acccepted', (t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: { changes: [] },
         abort: function() {
             t.fail('should not abort');
@@ -1851,7 +1851,7 @@ test('[commands.operations.confirmChangeset] changeset formatting', (t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: {
             changes: [
                 { id: 'id', name: 'name', type: 'type', action: 'Modify', replacement: true },
@@ -1877,7 +1877,7 @@ test('[commands.operations.executeChangeSet] failure', (t) => {
         callback(new actions.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         abort: function(err) {
             t.ok(err instanceof actions.CloudFormationError, 'expected error type');
@@ -1892,13 +1892,13 @@ test('[commands.operations.executeChangeSet] failure', (t) => {
 
 test('[commands.operations.executeChangeSet] not executable', (t) => {
     sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
-        var err = new actions.ChangeSetNotExecutableError('failure');
+        const err = new actions.ChangeSetNotExecutableError('failure');
         err.execution = 'OBSOLETE';
         err.reason = 'outdated';
         callback(err);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         abort: function(err) {
             t.ok(err instanceof actions.ChangeSetNotExecutableError, 'expected error type');
@@ -1921,7 +1921,7 @@ test('[commands.operations.executeChangeSet] success', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         next: function() {
             t.pass('success');
@@ -1938,7 +1938,7 @@ test('[commands.operations.createPreamble] no template', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof template.NotFoundError, 'expected error type');
             t.equal(err.message, 'Could not load template: No template passed');
@@ -1955,7 +1955,7 @@ test('[commands.operations.createPreamble] template not found', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: '/tmp/invalid/path/nonono.template.json',
         abort: function(err) {
             t.ok(err instanceof template.NotFoundError, 'expected error type');
@@ -1977,7 +1977,7 @@ test('[commands.operations.createPreamble] template invalid', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
             t.ok(err instanceof template.InvalidTemplateError, 'expected error type');
@@ -2000,7 +2000,7 @@ test('[commands.operations.createPreamble] config bucket not found', (t) => {
         callback(new lookup.BucketNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
             t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
@@ -2023,7 +2023,7 @@ test('[commands.operations.createPreamble] failed to read configurations', (t) =
         callback(new lookup.S3Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
             t.ok(err instanceof lookup.S3Error, 'expected error type');
@@ -2050,7 +2050,7 @@ test('[commands.operations.createPreamble] success', (t) => {
         callback(null, ['config']);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         overrides: { templateOptions: { template: 'options' } },
         next: function(err) {
@@ -2080,7 +2080,7 @@ test('[commands.operations.createPreamble] success with template object', (t) =>
         callback(null, ['config']);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         template: { arbitrary: 'template' },
         overrides: { templateOptions: { template: 'options' } },
         next: function(err) {
@@ -2103,7 +2103,7 @@ test('[commands.operations.selectConfig] force-mode', (t) => {
         callback(new Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
             t.ifError(err, 'success');
@@ -2122,7 +2122,7 @@ test('[commands.operations.selectConfig] new config', (t) => {
         return Promise.resolve('New configuration');
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configNames: ['config'],
         next: function(err) {
             t.ifError(err, 'success');
@@ -2141,7 +2141,7 @@ test('[commands.operations.selectConfig] saved config', (t) => {
         return Promise.resolve('config');
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configNames: ['config'],
         next: function(err) {
             t.ifError(err, 'success');
@@ -2155,7 +2155,7 @@ test('[commands.operations.selectConfig] saved config', (t) => {
 });
 
 test('[commands.operations.loadConfig] no saved config, no default', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.oldParameters, {}, 'does not set context.oldParameters');
@@ -2172,7 +2172,7 @@ test('[commands.operations.loadConfig] no saved config, has default', (t) => {
         callback(null, { default: 'configuration' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { defaultConfig: 's3://my-bucket/my-default.cfn.json' },
         next: function(err) {
             t.ifError(err, 'success');
@@ -2190,7 +2190,7 @@ test('[commands.operations.loadConfig] bucket not found', (t) => {
         callback(new lookup.BucketNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
             t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
@@ -2208,7 +2208,7 @@ test('[commands.operations.loadConfig] config not found', (t) => {
         callback(new lookup.ConfigurationNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
             t.ok(err instanceof lookup.ConfigurationNotFoundError, 'expected error type');
@@ -2226,7 +2226,7 @@ test('[commands.operations.loadConfig] invalid config', (t) => {
         callback(new lookup.InvalidConfigurationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
             t.ok(err instanceof lookup.InvalidConfigurationError, 'expected error type');
@@ -2244,7 +2244,7 @@ test('[commands.operations.loadConfig] failed to load config', (t) => {
         callback(new lookup.S3Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
             t.ok(err instanceof lookup.S3Error, 'expected error type');
@@ -2265,7 +2265,7 @@ test('[commands.operations.loadConfig] success', (t) => {
         callback(null, { saved: 'configuration' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         next: function(err) {
             t.ifError(err, 'success');
@@ -2284,7 +2284,7 @@ test('[commands.operations.confirmCreate] force-mode', (t) => {
         callback(new Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
             t.ifError(err, 'success');
@@ -2301,7 +2301,7 @@ test('[commands.operations.confirmCreate] reject', (t) => {
         return Promise.resolve(false);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         abort: function(err) {
             t.ifError(err, 'aborted');
@@ -2319,7 +2319,7 @@ test('[commands.operations.confirmCreate] accept', (t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         configName: 'config',
         next: function(err) {
             t.ifError(err, 'success');
@@ -2332,7 +2332,7 @@ test('[commands.operations.confirmCreate] accept', (t) => {
 });
 
 test('[commands.operations.confirmDelete] force-mode', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
             t.ifError(err, 'no prompt');
@@ -2350,7 +2350,7 @@ test('[commands.operations.confirmDelete] reject', (t) => {
         return Promise.resolve(false);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ifError(err, 'aborted');
             prompt.confirm.restore();
@@ -2368,7 +2368,7 @@ test('[commands.operations.confirmDelete] accept', (t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
             prompt.confirm.restore();
@@ -2384,7 +2384,7 @@ test('[commands.operations.deleteStack] failure', (t) => {
         callback(new actions.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof actions.CloudFormationError, 'expected error type');
             t.equal(err.message, 'Failed to delete stack: failure', 'expected error message');
@@ -2403,7 +2403,7 @@ test('[commands.operations.deleteStack] success', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
             actions.delete.restore();
@@ -2419,7 +2419,7 @@ test('[commands.operations.monitorStack] failure', (t) => {
         callback(new actions.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.equal(err.message, `Monitoring your deploy failed, but the deploy in region ${context.stackRegion} will continue. Check on your stack's status in the CloudFormation console.`);
             actions.monitor.restore();
@@ -2437,7 +2437,7 @@ test('[commands.operations.monitorStack] success', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
             actions.monitor.restore();
@@ -2453,7 +2453,7 @@ test('[commands.operations.getOldParameters] missing stack', (t) => {
         callback(new lookup.StackNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof lookup.StackNotFoundError, 'expected error type');
             t.equal(err.message, 'Missing stack: failure', 'expected error message');
@@ -2470,7 +2470,7 @@ test('[commands.operations.getOldParameters] failed to lookup stack', (t) => {
         callback(new lookup.CloudFormationError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ok(err instanceof lookup.CloudFormationError, 'expected error type');
             t.equal(err.message, 'Failed to find existing stack: failure', 'expected error message');
@@ -2489,7 +2489,7 @@ test('[commands.operations.getOldParameters] success', (t) => {
         callback(null, { old: 'parameters' });
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.oldParameters, { old: 'parameters' }, 'set context.oldParameters');
@@ -2508,7 +2508,7 @@ test('[commands.operations.promptSaveConfig]', (t) => {
         return Promise.resolve('chuck');
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         next: function(err) {
             t.ifError(err, 'success');
@@ -2526,7 +2526,7 @@ test('[commands.operations.confirmSaveConfig] reject', (t) => {
         return Promise.resolve(false);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         abort: function(err) {
             t.ifError(err, 'aborted');
@@ -2544,7 +2544,7 @@ test('[commands.operations.confirmSaveConfig] accept', (t) => {
         return Promise.resolve(true);
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         saveName: 'hello',
         oldParameters: { old: 'parameters' },
         next: function(err) {
@@ -2562,7 +2562,7 @@ test('[commands.operations.saveConfig] bucket not found', (t) => {
         callback(new actions.BucketNotFoundError('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         kms: true,
         abort: function(err) {
@@ -2581,7 +2581,7 @@ test('[commands.operations.saveConfig] failure', (t) => {
         callback(new actions.S3Error('failure'));
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         kms: true,
         abort: function(err) {
@@ -2606,7 +2606,7 @@ test('[commands.operations.saveConfig] success', (t) => {
         callback();
     });
 
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         newParameters: { new: 'parameters' },
         overrides: { kms: true },
         next: function(err) {
@@ -2620,7 +2620,7 @@ test('[commands.operations.saveConfig] success', (t) => {
 });
 
 test('[commands.operations.mergeMetadata]', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
         oldParameters: { old: 'parameters' },
@@ -2639,7 +2639,7 @@ test('[commands.operations.mergeMetadata]', (t) => {
 });
 
 test('[commands.operations.mergeMetadata] error', (t) => {
-    var context = Object.assign({}, basicContext, {
+    const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template', Metadata: { LastDeploy: 'jane' } },
         oldParameters: { old: 'parameters' },

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -20,7 +20,7 @@ const opts = {
     templateBucket: 'my-template-bucket'
 };
 
-test('[commands.create] no overrides', async (t) => {
+test('[commands.create] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -37,7 +37,7 @@ test('[commands.create] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.create] with overrides', async (t) => {
+test('[commands.create] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -55,7 +55,7 @@ test('[commands.create] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.create] with template object', async (t) => {
+test('[commands.create] with template object', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -72,7 +72,7 @@ test('[commands.create] with template object', async (t) => {
     t.end();
 });
 
-test('[commands.update] no overrides', async (t) => {
+test('[commands.update] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -90,7 +90,7 @@ test('[commands.update] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides', async (t) => {
+test('[commands.update] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -107,7 +107,7 @@ test('[commands.update] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with multiple overrides', async (t) => {
+test('[commands.update] with multiple overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -124,7 +124,7 @@ test('[commands.update] with multiple overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters', async (t) => {
+test('[commands.update] with overrides.skipConfirmParameters', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -142,7 +142,7 @@ test('[commands.update] with overrides.skipConfirmParameters', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmTemplate', async (t) => {
+test('[commands.update] with overrides.skipConfirmTemplate', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -159,7 +159,7 @@ test('[commands.update] with overrides.skipConfirmTemplate', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async (t) => {
+test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -176,7 +176,7 @@ test('[commands.update] with overrides.skipConfirmParameters and overrides.skipC
     t.end();
 });
 
-test('[commands.update] with template object', async (t) => {
+test('[commands.update] with template object', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -194,7 +194,7 @@ test('[commands.update] with template object', async (t) => {
     t.end();
 });
 
-test('[commands.delete] no overrides', async (t) => {
+test('[commands.delete] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -211,7 +211,7 @@ test('[commands.delete] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.delete] with overrides', async (t) => {
+test('[commands.delete] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -228,7 +228,7 @@ test('[commands.delete] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/o resources', async (t) => {
+test('[commands.info] success w/o resources', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -249,7 +249,7 @@ test('[commands.info] success w/o resources', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/ resources', async (t) => {
+test('[commands.info] success w/ resources', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -270,7 +270,7 @@ test('[commands.info] success w/ resources', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/o decrypt', async (t) => {
+test('[commands.info] success w/o decrypt', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -291,7 +291,7 @@ test('[commands.info] success w/o decrypt', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/ decrypt', async (t) => {
+test('[commands.info] success w/ decrypt', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -311,7 +311,7 @@ test('[commands.info] success w/ decrypt', async (t) => {
     t.end();
 });
 
-test('[commands.info] null provided as suffix', async (t) => {
+test('[commands.info] null provided as suffix', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack', 'no trailing - on stack name');
         return Promise.resolve();
@@ -329,7 +329,7 @@ test('[commands.info] null provided as suffix', async (t) => {
     t.end();
 });
 
-test('[commands.save] kms-mode', async (t) => {
+test('[commands.save] kms-mode', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -345,7 +345,7 @@ test('[commands.save] kms-mode', async (t) => {
     t.end();
 });
 
-test('[commands.save] not kms-mode', async (t) => {
+test('[commands.save] not kms-mode', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -362,7 +362,7 @@ test('[commands.save] not kms-mode', async (t) => {
 });
 
 test('[commands.commandContext] sets context', (t) => {
-    const context = commands.commandContext(opts, 'testing', opts, function() {});
+    const context = new CommandContext(opts, 'testing', opts);
     t.equal(context.baseName, opts.name, 'sets baseName');
     t.equal(context.suffix, 'testing', 'sets suffix');
     t.equal(context.stackName, opts.name + '-testing', 'sets stackName');
@@ -371,42 +371,40 @@ test('[commands.commandContext] sets context', (t) => {
     t.equal(context.templateBucket, opts.templateBucket, 'sets templateBucket');
     t.deepEqual(context.overrides, {}, 'sets empty overrides');
     t.deepEqual(context.oldParameters, {}, 'sets empty oldParameters');
-    t.equal(typeof context.abort, 'function', 'sets abort function');
-    t.equal(typeof context.next, 'function', 'sets next function');
     t.end();
 });
 
 test('[commands.commandContext] handles null suffix', (t) => {
-    const context = commands.commandContext(opts, null, opts, function() {});
+    const context = new CommandContext(opts, null, opts);
     t.equal(context.stackName, opts.name, 'sets stackName without trailing -');
     t.end();
 });
 
-test('[commands.commandContext] iterates through operations', (t) => {
-    const i = 0;
+test('[commands.commandContext] iterates through operations', async(t) => {
+    let i = 0;
     const ops = [
-        function(context) {
+        async function(context) {
             t.equal(i, 0, 'called first function');
             i++;
-            context.next();
         },
-        function(context) {
+        async function(context) {
             t.equal(i, 1, 'called second function');
             i++;
-            context.next();
         }
     ];
 
-    const context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
-        t.ifError(err, 'success');
-        t.equal(performed, true, 'the requested command was performed');
-        t.end();
-    });
+    const context = new CommandContext(opts, 'testing', ops);
+    try {
+        await context.run();
+        t.equals(i, 2);
+    } catch (err) {
+        t.error(err);
+    }
 
-    context.next();
+    t.end();
 });
 
-test('[commands.commandContext] callback with diffs', (t) => {
+test('[commands.commandContext] callback with diffs', async(t) => {
     const ops = [
         commands.operations.confirmParameters,
         commands.operations.confirmTemplate
@@ -416,7 +414,7 @@ test('[commands.commandContext] callback with diffs', (t) => {
         return Promise.resolve(true);
     });
 
-    const context = commands.commandContext(opts, 'testing', ops, function(err, performed, diffs) {
+    const context = new CommandContext(opts, 'testing', ops, function(err, performed, diffs) {
         t.ifError(err, 'success');
         t.equal(performed, true, 'the requested command was performed');
         t.deepEqual(diffs, {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -313,7 +313,7 @@ test('[commands.info] success w/ decrypt', async(t) => {
 });
 
 test('[commands.info] null provided as suffix', async(t) => {
-    sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
+    sinon.stub(Lookup, 'info').callsFake((name) => {
         t.equal(name, 'my-stack', 'no trailing - on stack name');
         return Promise.resolve();
     });
@@ -384,11 +384,11 @@ test('[commands.commandContext] handles null suffix', (t) => {
 test('[commands.commandContext] iterates through operations', async(t) => {
     let i = 0;
     const ops = [
-        async function(context) {
+        async() => {
             t.equal(i, 0, 'called first function');
             i++;
         },
-        async function(context) {
+        async() => {
             t.equal(i, 1, 'called second function');
             i++;
         }
@@ -475,7 +475,7 @@ test('[commands.commandContext] aborts with error', async(t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] no template', async(t) => {
+test('[Operations.updatePreamble] no template', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake(() => {
         return Promise.resolve();
     });
@@ -500,12 +500,12 @@ test('[commands.operations.updatePreamble] no template', async(t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] templatePath not found', async(t) => {
-    sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
+test('[Operations.updatePreamble] templatePath not found', async(t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
         return Promise.resolve();
     });
 
-    sinon.stub(Lookup, 'template').callsFake((name, region) => {
+    sinon.stub(Lookup, 'template').callsFake(() => {
         return Promise.resolve();
     });
 
@@ -527,7 +527,7 @@ test('[commands.operations.updatePreamble] templatePath not found', async(t) => 
     t.end();
 });
 
-test('[commands.operations.updatePreamble] template invalid', async(t) => {
+test('[Operations.updatePreamble] template invalid', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         throw new Template.InvalidTemplateError('failure');
     });
@@ -557,7 +557,7 @@ test('[commands.operations.updatePreamble] template invalid', async(t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] stack not found for parameters', async(t) => {
+test('[Operations.updatePreamble] stack not found for parameters', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -588,7 +588,7 @@ test('[commands.operations.updatePreamble] stack not found for parameters', asyn
     t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack parameters', async(t) => {
+test('[Operations.updatePreamble] failure getting stack parameters', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -620,7 +620,7 @@ test('[commands.operations.updatePreamble] failure getting stack parameters', as
 
 });
 
-test('[commands.operations.updatePreamble] stack not found for template', async(t) => {
+test('[Operations.updatePreamble] stack not found for template', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -651,7 +651,7 @@ test('[commands.operations.updatePreamble] stack not found for template', async(
     t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack template', async(t) => {
+test('[Operations.updatePreamble] failure getting stack template', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -682,7 +682,7 @@ test('[commands.operations.updatePreamble] failure getting stack template', asyn
     t.end();
 });
 
-test('[commands.operations.updatePreamble] success', async(t) => {
+test('[Operations.updatePreamble] success', async(t) => {
     sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
@@ -693,7 +693,7 @@ test('[commands.operations.updatePreamble] success', async(t) => {
         return Promise.resolve({ old: 'parameters' });
     });
 
-    sinon.stub(Lookup, 'template').callsFake((name, region) => {
+    sinon.stub(Lookup, 'template').callsFake(() => {
         return Promise.resolve({ old: 'template' });
     });
 
@@ -717,7 +717,7 @@ test('[commands.operations.updatePreamble] success', async(t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] success with template object', async(t) => {
+test('[Operations.updatePreamble] success with template object', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake(() => {
         return Promise.resolve({ old: 'parameters' });
     });
@@ -744,7 +744,7 @@ test('[commands.operations.updatePreamble] success with template object', async(
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] success', async(t) => {
+test('[Operations.getMasterConfig] success', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ old: 'fresh' });
     });
@@ -765,7 +765,7 @@ test('[commands.operations.getMasterConfig] success', async(t) => {
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] no-op', async(t) => {
+test('[Operations.getMasterConfig] no-op', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ old: 'fresh' });
     });
@@ -787,7 +787,7 @@ test('[commands.operations.getMasterConfig] no-op', async(t) => {
 
 });
 
-test('[commands.operations.getMasterConfig] failed', async(t) => {
+test('[Operations.getMasterConfig] failed', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         throw new Error();
     });
@@ -807,7 +807,7 @@ test('[commands.operations.getMasterConfig] failed', async(t) => {
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', async(t) => {
+test('[Operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ bingo: 'fresh' });
     });
@@ -828,7 +828,7 @@ test('[commands.operations.getMasterConfig] no matching oldParameters does not p
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', async(t) => {
+test('[Operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ old: 'fresh' });
     });
@@ -840,7 +840,7 @@ test('[commands.operations.getMasterConfig] adding a newParameter that matches m
         context.oldParameters = { hello: 'goodbye' };
         context.newTemplate = {};
         context.newTemplate.Parameters = { old: 'special whale' };
-        commands.operations.getMasterConfig(context);
+        Operations.getMasterConfig(context);
 
         t.deepEqual(context.oldParameters, { hello: 'goodbye' }, 'no matching keys between oldParameters and masterConfig, no oldParameters are replaced');
         t.deepEqual(context.newTemplate.Parameters, { old: 'special whale' }, 'newParameters are not replaced despite matching keys');
@@ -852,7 +852,7 @@ test('[commands.operations.getMasterConfig] adding a newParameter that matches m
     t.end();
 });
 
-test('[commands.operations.promptParameters] force-mode', async(t) => {
+test('[Operations.promptParameters] force-mode', async(t) => {
     sinon.stub(Template, 'questions').callsFake(() => {
         t.fail('should not build questions');
     });
@@ -875,7 +875,7 @@ test('[commands.operations.promptParameters] force-mode', async(t) => {
     t.end();
 });
 
-test('[commands.operations.promptParameters] not force-mode', async(t) => {
+test('[Operations.promptParameters] not force-mode', async(t) => {
     const questions = { parameter: 'questions' };
     const answers = { parameter: 'answers' };
 
@@ -907,7 +907,7 @@ test('[commands.operations.promptParameters] not force-mode', async(t) => {
     t.end();
 });
 
-test('[commands.operations.promptParameters] with parameter and kms overrides', async(t) => {
+test('[Operations.promptParameters] with parameter and kms overrides', async(t) => {
     sinon.stub(Template, 'questions').callsFake((template, overrides) => {
         t.deepEqual(overrides, { defaults: { old: 'overriden' }, kmsKeyId: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
         return { parameter: 'questions' };
@@ -917,57 +917,62 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
         return Promise.resolve({ the: 'answers' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        stackRegion: 'us-west-2',
-        newTemplate: { new: 'template' },
-        oldParameters: { old: 'parameters' },
-        overrides: { parameters: { old: 'overriden' }, kms: 'this is a bomb key' },
-        next: function(err) {
-            t.ifError(err, 'success');
-            template.questions.restore();
-            Prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.stackRegion = 'us-west-2',
+        context.newTemplate = { new: 'template' },
+        context.oldParameters = { old: 'parameters' },
+        context.overrides = { parameters: { old: 'overriden' }, kms: 'this is a bomb key' },
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+    } catch (err) {
+        t.error(err);
+    }
+
+    Template.questions.restore();
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] force-mode with no parameters in new template', async(t) => {
-    const context = Object.assign({}, basicContext, {
-        newTemplate: { new: 'template' },
-        overrides: { force: true },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.deepEqual(context.newParameters, {}, 'sets context.newParameters to empty');
-            t.end();
-        }
-    });
+test('[Operations.promptParameters] force-mode with no parameters in new template', async(t) => {
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.newTemplate = { new: 'template' },
+        context.overrides = { force: true },
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.deepEqual(context.newParameters, {}, 'sets context.newParameters to empty');
+    } catch (err) {
+        t.error(err);
+    }
+
+    t.end();
 });
 
-test('[commands.operations.promptParameters] reject overrides that are not in old or new template', async(t) => {
+test('[Operations.promptParameters] reject overrides that are not in old or new template', async(t) => {
     sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve({ some: 'answers' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        newTemplate: { Parameters: { Name: {} } },
-        oldParameters: { Name: 'name', Age: 'age' },
-        overrides: { parameters: { Name: 'overriden', Born: 'ignored' } },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.notOk(context.oldParameters.Born, 'excludes extraneous parameter override');
-            Prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.newTemplate = { Parameters: { Name: {} } };
+        context.oldParameters = { Name: 'name', Age: 'age' };
+        context.overrides = { parameters: { Name: 'overriden', Born: 'ignored' } };
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.notOk(context.oldParameters.Born, 'excludes extraneous parameter override');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', async(t) => {
+test('[Operations.promptParameters] changesetParameters use previous value for unchanged parameter values', async(t) => {
     const oldParameters = { old: 'parameters', the: 'answers' };
     const newParameters = { old: 'newvalue', the: 'answers' };
 
@@ -988,10 +993,10 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
         }
     });
 
-    commands.operations.promptParameters(context);
+    await Operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', async(t) => {
+test('[Operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', async(t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
@@ -999,23 +1004,24 @@ test('[commands.operations.promptParameters] changesetParameters does not set Us
         return Promise.resolve(newParameters);
     });
 
-    const context = Object.assign({}, basicContext, {
-        stackRegion: 'us-west-2',
-        newTemplate: { new: 'template' },
-        oldParameters: oldParameters,
-        overrides: { parameters: { beep: 'boop' } },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
-            Prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.stackRegion = 'us-west-2',
+        context.newTemplate = { new: 'template' },
+        context.oldParameters = oldParameters,
+        context.overrides = { parameters: { beep: 'boop' } },
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
+    } catch (err) {
+        t.error(err);
+    }
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', async(t) => {
+test('[Operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', async(t) => {
     const oldParameters = { beep: 'bop' };
     const newParameters = { beep: 'bop' };
 
@@ -1023,23 +1029,25 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
         return Promise.resolve(newParameters);
     });
 
-    const context = Object.assign({}, basicContext, {
-        stackRegion: 'us-west-2',
-        newTemplate: { new: 'template' },
-        oldParameters: oldParameters,
-        overrides: {},
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', UsePreviousValue: true }]);
-            Prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.stackRegion = 'us-west-2',
+        context.newTemplate = { new: 'template' },
+        context.oldParameters = oldParameters,
+        context.overrides = {},
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', UsePreviousValue: true }]);
+    } catch (err) {
+        t.error(err);
+    }
+
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', async(t) => {
+test('[Operations.promptParameters] do not set UsePreviousValue when creating a new stack', async(t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
@@ -1047,73 +1055,84 @@ test('[commands.operations.promptParameters] do not set UsePreviousValue when cr
         return Promise.resolve(newParameters);
     });
 
-    const context = Object.assign({}, basicContext, {
-        stackRegion: 'us-west-2',
-        newTemplate: { new: 'template' },
-        create: true,
-        oldParameters: oldParameters,
-        overrides: { parameters: { beep: 'boop' } },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.ok(context.create, 'context.create is set to true');
-            t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
-            Prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.stackRegion = 'us-west-2';
+        context.newTemplate = { new: 'template' };
+        context.create = true;
+        context.oldParameters = oldParameters;
+        context.overrides = { parameters: { beep: 'boop' } };
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.ok(context.create, 'context.create is set to true');
+        t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
+    } catch (err) {
+        t.error(err);
+    }
+
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.confirmParameters] force-mode', async(t) => {
-    const context = Object.assign({}, basicContext, {
-        overrides: { force: true },
-        oldParameters: { old: 'parameters' },
-        newParameters: { old: 'parameters' },
-        next: function() {
-            t.pass('skipped prompting');
-            t.end();
-        }
-    });
+test('[Operations.confirmParameters] force-mode', async(t) => {
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = { force: true };
+        context.oldParameters = { old: 'parameters' };
+        context.newParameters = { old: 'parameters' };
 
-    commands.operations.confirmParameters(context);
+        await Operations.confirmParameters(context);
+
+        t.pass('skipped prompting');
+    } catch (err) {
+        t.error(err);
+    }
+
+    t.end();
 });
 
-test('[commands.operations.confirmParameters] no difference', async(t) => {
-    const context = Object.assign({}, basicContext, {
-        oldParameters: { old: 'parameters' },
-        newParameters: { old: 'parameters' },
-        next: function() {
-            t.pass('skipped prompting');
-            t.end();
-        }
-    });
+test('[Operations.confirmParameters] no difference', async(t) => {
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.oldParameters = { old: 'parameters' };
+        context.newParameters = { old: 'parameters' };
 
-    commands.operations.confirmParameters(context);
+        await Operations.confirmParameters(context);
+
+        t.pass('skipped prompting');
+    } catch (err) {
+        t.error(err);
+    }
+
+    t.end();
 });
 
-test('[commands.operations.confirmParameters] preapproved', async(t) => {
+test('[Operations.confirmParameters] preapproved', async(t) => {
     sinon.stub(console, 'log');
 
-    const context = Object.assign({}, basicContext, {
-        oldParameters: { old: 'parameters' },
-        newParameters: { old: 'parameters', newones: 'too' },
-        overrides: {
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.oldParameters = { old: 'parameters' };
+        context.newParameters = { old: 'parameters', newones: 'too' };
+        context.overrides = {
             preapproved: { parameters: [' {\n\u001b[32m+  newones: "too"\u001b[39m\n }\n'] }
-        },
-        next: function() {
-            t.ok(console.log.calledWith('Auto-confirming parameter changes... Changes were pre-approved in another region.'), 'Skip notice printed');
-            t.pass('skipped prompting');
-            t.ok(context.overrides.skipConfirmParameters, 'sets skipConfirmParameters');
-            console.log.restore();
-            t.end();
-        }
-    });
+        };
 
-    await commands.operations.confirmParameters(context);
+        await Operations.confirmParameters(context);
+
+        t.ok(console.log.calledWith('Auto-confirming parameter changes... Changes were pre-approved in another region.'), 'Skip notice printed');
+        t.pass('skipped prompting');
+        t.ok(context.overrides.skipConfirmParameters, 'sets skipConfirmParameters');
+    } catch (err) {
+        t.error(err);
+    }
+
+    console.log.restore();
+    t.end();
 });
 
-test('[commands.operations.confirmParameters] rejected', async(t) => {
+test('[Operations.confirmParameters] rejected', async(t) => {
     t.plan(2);
 
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
@@ -1121,22 +1140,24 @@ test('[commands.operations.confirmParameters] rejected', async(t) => {
         return Promise.resolve(false);
     });
 
-    await commands.operations.confirmParameters(Object.assign({}, basicContext, {
-        oldParameters: { old: 'parameters' },
-        newParameters: { new: 'parameterz' },
-        overrides: {},
-        next: function() {
-            t.fail('should not proceed');
-        },
-        abort: function(err) {
-            t.ifError(err, 'aborted');
-            Prompt.confirm.restore();
-            t.end();
-        }
-    }));
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.oldParameters = { old: 'parameters' };
+        context.newParameters = { new: 'parameterz' };
+        context.overrides = {};
+
+        await Operations.confirmParameters(context);
+
+        t.fail();
+    } catch (err) {
+        t.equals(err.message, 'aborted'); // new
+    }
+
+    Prompt.confirm.restore();
+    t.end();
 });
 
-test('[commands.operations.confirmParameters] accepted', async(t) => {
+test('[Operations.confirmParameters] accepted', async(t) => {
     t.plan(2);
 
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
@@ -1144,7 +1165,7 @@ test('[commands.operations.confirmParameters] accepted', async(t) => {
         return Promise.resolve(true);
     });
 
-    await commands.operations.confirmParameters(Object.assign({}, basicContext, {
+    await Operations.confirmParameters(Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         newParameters: { new: 'parameters' },
         overrides: {},
@@ -1159,7 +1180,7 @@ test('[commands.operations.confirmParameters] accepted', async(t) => {
     }));
 });
 
-test('[commands.operations.confirmTemplate] no difference', async(t) => {
+test('[Operations.confirmTemplate] no difference', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { old: 'template' },
@@ -1169,10 +1190,10 @@ test('[commands.operations.confirmTemplate] no difference', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] undefined', async(t) => {
+test('[Operations.confirmTemplate] undefined', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { Parameters: { old: undefined } },
         newTemplate: { Parameters: {} },
@@ -1182,10 +1203,10 @@ test('[commands.operations.confirmTemplate] undefined', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] force-mode', async(t) => {
+test('[Operations.confirmTemplate] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
@@ -1199,10 +1220,10 @@ test('[commands.operations.confirmTemplate] force-mode', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] preapproved', async(t) => {
+test('[Operations.confirmTemplate] preapproved', async(t) => {
     sinon.stub(console, 'log');
 
     const context = Object.assign({}, basicContext, {
@@ -1225,10 +1246,10 @@ test('[commands.operations.confirmTemplate] preapproved', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] rejected', async(t) => {
+test('[Operations.confirmTemplate] rejected', async(t) => {
     t.plan(2);
 
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
@@ -1254,10 +1275,10 @@ test('[commands.operations.confirmTemplate] rejected', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] accepted', async(t) => {
+test('[Operations.confirmTemplate] accepted', async(t) => {
     t.plan(2);
 
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
@@ -1278,10 +1299,10 @@ test('[commands.operations.confirmTemplate] accepted', async(t) => {
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', async(t) => {
+test('[Operations.confirmTemplate] lengthy diff, first unchanged section ignored', async(t) => {
     t.plan(2);
 
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
@@ -1376,10 +1397,10 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
         }
     });
 
-    await commands.operations.confirmTemplate(context);
+    await Operations.confirmTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] bucket not found', async(t) => {
+test('[Operations.saveTemplate] bucket not found', async(t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(Actions, 'templateUrl').callsFake(() => {
@@ -1400,10 +1421,10 @@ test('[commands.operations.saveTemplate] bucket not found', async(t) => {
         }
     });
 
-    commands.operations.saveTemplate(context);
+    await Operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] failed to save template', async(t) => {
+test('[Operations.saveTemplate] failed to save template', async(t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(Actions, 'templateUrl').callsFake(() => {
@@ -1424,10 +1445,10 @@ test('[commands.operations.saveTemplate] failed to save template', async(t) => {
         }
     });
 
-    commands.operations.saveTemplate(context);
+    await Operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] success', async(t) => {
+test('[Operations.saveTemplate] success', async(t) => {
     const templateUrl = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
     sinon.stub(Actions, 'templateUrl').callsFake((bucket, region, suffix) => {
@@ -1455,10 +1476,10 @@ test('[commands.operations.saveTemplate] success', async(t) => {
         }
     });
 
-    commands.operations.saveTemplate(context);
+    await Operations.saveTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] invalid', async(t) => {
+test('[Operations.validateTemplate] invalid', async(t) => {
     sinon.stub(Actions, 'validate').callsFake(() => {
         throw new Actions.CloudFormationError('failure');
     });
@@ -1473,10 +1494,10 @@ test('[commands.operations.validateTemplate] invalid', async(t) => {
         }
     });
 
-    commands.operations.validateTemplate(context);
+    await Operations.validateTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] valid', async(t) => {
+test('[Operations.validateTemplate] valid', async(t) => {
     t.plan(3);
 
     sinon.stub(Actions, 'validate').callsFake((region, url) => {
@@ -1496,10 +1517,10 @@ test('[commands.operations.validateTemplate] valid', async(t) => {
         }
     });
 
-    commands.operations.validateTemplate(context);
+    await Operations.validateTemplate(context);
 });
 
-test('[commands.operations.beforeUpdateHook] no hook', async(t) => {
+test('[Operations.beforeUpdateHook] no hook', async(t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1510,10 +1531,10 @@ test('[commands.operations.beforeUpdateHook] no hook', async(t) => {
         }
     });
 
-    commands.operations.beforeUpdateHook(context);
+    await Operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.validateParametersHook] no hook', async(t) => {
+test('[Operations.validateParametersHook] no hook', async(t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1524,10 +1545,10 @@ test('[commands.operations.validateParametersHook] no hook', async(t) => {
         }
     });
 
-    commands.operations.validateParametersHook(context);
+    await Operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook error', async(t) => {
+test('[Operations.validateParametersHook] hook error', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             validateParameters: function(context, callback) {
@@ -1543,10 +1564,10 @@ test('[commands.operations.validateParametersHook] hook error', async(t) => {
         }
     });
 
-    commands.operations.validateParametersHook(context);
+    await Operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook success', async(t) => {
+test('[Operations.validateParametersHook] hook success', async(t) => {
     t.plan(2);
     const context = Object.assign({}, basicContext, {
         overrides: {
@@ -1563,10 +1584,10 @@ test('[commands.operations.validateParametersHook] hook success', async(t) => {
         }
     });
 
-    commands.operations.validateParametersHook(context);
+    await Operations.validateParametersHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook error', async(t) => {
+test('[Operations.beforeUpdateHook] hook error', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             beforeUpdate: function(context, callback) {
@@ -1582,10 +1603,10 @@ test('[commands.operations.beforeUpdateHook] hook error', async(t) => {
         }
     });
 
-    commands.operations.beforeUpdateHook(context);
+    await Operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook success', async(t) => {
+test('[Operations.beforeUpdateHook] hook success', async(t) => {
     t.plan(2);
 
     const context = Object.assign({}, basicContext, {
@@ -1603,10 +1624,10 @@ test('[commands.operations.beforeUpdateHook] hook success', async(t) => {
         }
     });
 
-    commands.operations.beforeUpdateHook(context);
+    await Operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.getChangeset] failure', async(t) => {
+test('[Operations.getChangeset] failure', async(t) => {
     sinon.stub(Actions, 'diff').callsFake(() => {
         throw new Actions.CloudFormationError('failure');
     });
@@ -1623,10 +1644,10 @@ test('[commands.operations.getChangeset] failure', async(t) => {
         }
     });
 
-    commands.operations.getChangeset(context);
+    await Operations.getChangeset(context);
 });
 
-test('[commands.operations.getChangeset] success', async(t) => {
+test('[Operations.getChangeset] success', async(t) => {
     t.plan(8);
 
     const details = { changeset: 'details' };
@@ -1659,10 +1680,10 @@ test('[commands.operations.getChangeset] success', async(t) => {
         }
     });
 
-    commands.operations.getChangeset(context, 'UPDATE');
+    await Operations.getChangeset(context, 'UPDATE');
 });
 
-test('[commands.operations.getChangesetCreate] success', async(t) => {
+test('[Operations.getChangesetCreate] success', async(t) => {
     t.plan(1);
 
     sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
@@ -1672,15 +1693,15 @@ test('[commands.operations.getChangesetCreate] success', async(t) => {
 
     const context = {
         next: function() {
-            commands.operations.getChangeset.restore();
+            Operations.getChangeset.restore();
             t.end();
         }
     };
 
-    commands.operations.getChangesetCreate(context);
+    await Operations.getChangesetCreate(context);
 });
 
-test('[commands.operations.getChangesetUpdate] success', async(t) => {
+test('[Operations.getChangesetUpdate] success', async(t) => {
     t.plan(1);
 
     sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
@@ -1690,15 +1711,15 @@ test('[commands.operations.getChangesetUpdate] success', async(t) => {
 
     const context = {
         next: function() {
-            commands.operations.getChangeset.restore();
+            Operations.getChangeset.restore();
             t.end();
         }
     };
 
-    commands.operations.getChangesetUpdate(context);
+    await Operations.getChangesetUpdate(context);
 });
 
-test('[commands.operations.confirmChangeset] force-mode', async(t) => {
+test('[Operations.confirmChangeset] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function() {
@@ -1710,10 +1731,10 @@ test('[commands.operations.confirmChangeset] force-mode', async(t) => {
         }
     });
 
-    commands.operations.confirmChangeset(context);
+    await Operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', async(t) => {
+test('[Operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { skipConfirmParameters: true, skipConfirmTemplate: true },
         next: function() {
@@ -1725,10 +1746,10 @@ test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTem
         }
     });
 
-    commands.operations.confirmChangeset(context);
+    await Operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] rejected', async(t) => {
+test('[Operations.confirmChangeset] rejected', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(defaultValue, false);
         return Promise.resolve(false);
@@ -1743,10 +1764,10 @@ test('[commands.operations.confirmChangeset] rejected', async(t) => {
         }
     });
 
-    commands.operations.confirmChangeset(context);
+    await Operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] acccepted', async(t) => {
+test('[Operations.confirmChangeset] acccepted', async(t) => {
     t.plan(3);
 
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
@@ -1766,10 +1787,10 @@ test('[commands.operations.confirmChangeset] acccepted', async(t) => {
         }
     });
 
-    commands.operations.confirmChangeset(context);
+    await Operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] changeset formatting', async(t) => {
+test('[Operations.confirmChangeset] changeset formatting', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Action  Name  Type  Replace\n------  ----  ----  -------\n\x1b[33mModify\x1b[39m  name  type  \x1b[31mtrue\x1b[39m   \n\x1b[32mAdd\x1b[39m     name  type  \x1b[32mfalse\x1b[39m  \n\x1b[31mRemove\x1b[39m  name  type  \x1b[32mfalse\x1b[39m  \n\nAccept changes and update the stack?', 'expected message (with colors)');
         t.equal(defaultValue, false);
@@ -1794,11 +1815,11 @@ test('[commands.operations.confirmChangeset] changeset formatting', async(t) => 
         }
     });
 
-    commands.operations.confirmChangeset(context);
+    await Operations.confirmChangeset(context);
 });
 
-test('[commands.operations.executeChangeSet] failure', async(t) => {
-    sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
+test('[Operations.executeChangeSet] failure', async(t) => {
+    sinon.stub(Actions, 'executeChangeSet').callsFake(() => {
         throw new Actions.CloudFormationError('failure');
     });
 
@@ -1812,11 +1833,11 @@ test('[commands.operations.executeChangeSet] failure', async(t) => {
         }
     });
 
-    commands.operations.executeChangeSet(context);
+    await Operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] not executable', async(t) => {
-    sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
+test('[Operations.executeChangeSet] not executable', async(t) => {
+    sinon.stub(Actions, 'executeChangeSet').callsFake(() => {
         const err = new Actions.ChangeSetNotExecutableError('failure');
         err.execution = 'OBSOLETE';
         err.reason = 'outdated';
@@ -1833,10 +1854,10 @@ test('[commands.operations.executeChangeSet] not executable', async(t) => {
         }
     });
 
-    commands.operations.executeChangeSet(context);
+    await Operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] success', async(t) => {
+test('[Operations.executeChangeSet] success', async(t) => {
     t.plan(4);
 
     sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
@@ -1856,27 +1877,27 @@ test('[commands.operations.executeChangeSet] success', async(t) => {
         }
     });
 
-    commands.operations.executeChangeSet(context);
+    await Operations.executeChangeSet(context);
 });
 
-test('[commands.operations.createPreamble] no template', async(t) => {
+test('[Operations.createPreamble] no template', async(t) => {
     sinon.stub(Lookup, 'configurations').callsFake(() => {
         return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof template.NotFoundError, 'expected error type');
+            t.ok(err instanceof Template.NotFoundError, 'expected error type');
             t.equal(err.message, 'Could not load template: No template passed');
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template not found', async(t) => {
+test('[Operations.createPreamble] template not found', async(t) => {
     sinon.stub(Lookup, 'configurations').callsFake(() => {
         return Promise.resolve();
     });
@@ -1884,18 +1905,18 @@ test('[commands.operations.createPreamble] template not found', async(t) => {
     const context = Object.assign({}, basicContext, {
         template: '/tmp/invalid/path/nonono.template.json',
         abort: function(err) {
-            t.ok(err instanceof template.NotFoundError, 'expected error type');
+            t.ok(err instanceof Template.NotFoundError, 'expected error type');
             t.equal(err.message, 'Could not load template: /tmp/invalid/path/nonono.template.json does not exist', 'expected error message');
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template invalid', async(t) => {
-    sinon.stub(template, 'read').callsFake(() => {
+test('[Operations.createPreamble] template invalid', async(t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
         throw new Template.InvalidTemplateError('failure');
     });
 
@@ -1906,19 +1927,19 @@ test('[commands.operations.createPreamble] template invalid', async(t) => {
     const context = Object.assign({}, basicContext, {
         template: 'example.template.json',
         abort: function(err) {
-            t.ok(err instanceof template.InvalidTemplateError, 'expected error type');
+            t.ok(err instanceof Template.InvalidTemplateError, 'expected error type');
             t.equal(err.message, 'Could not parse template: failure');
-            template.read.restore();
+            Template.read.restore();
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] config bucket not found', async(t) => {
-    sinon.stub(template, 'read').callsFake(() => {
+test('[Operations.createPreamble] config bucket not found', async(t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
 
@@ -1931,16 +1952,16 @@ test('[commands.operations.createPreamble] config bucket not found', async(t) =>
         abort: function(err) {
             t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find config bucket: failure');
-            template.read.restore();
+            Template.read.restore();
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] failed to read configurations', async(t) => {
+test('[Operations.createPreamble] failed to read configurations', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -1954,23 +1975,23 @@ test('[commands.operations.createPreamble] failed to read configurations', async
         abort: function(err) {
             t.ok(err instanceof Lookup.S3Error, 'expected error type');
             t.equal(err.message, 'Could not load saved configurations: failure');
-            template.read.restore();
+            Template.read.restore();
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success', async(t) => {
+test('[Operations.createPreamble] success', async(t) => {
     sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
         return Promise.resolve({ new: 'template' });
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake((name, bucket, region) => {
+    sinon.stub(Lookup, 'configurations').callsFake((name, bucket) => {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
         return Promise.resolve(['config']);
@@ -1984,23 +2005,23 @@ test('[commands.operations.createPreamble] success', async(t) => {
             t.deepEqual(context.newTemplate, { new: 'template' }, 'set context.newTemplate');
             t.deepEqual(context.configNames, ['config'], 'set context.configNames');
             t.ok(context.create, 'context.create is set to true');
-            template.read.restore();
+            Template.read.restore();
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success with template object', async(t) => {
+test('[Operations.createPreamble] success with template object', async(t) => {
     sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve(context.template), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
         return Promise.resolve(context.template);
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake((name, bucket, region) => {
+    sinon.stub(Lookup, 'configurations').callsFake((name, bucket) => {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
         return Promise.resolve(['config']);
@@ -2014,16 +2035,16 @@ test('[commands.operations.createPreamble] success with template object', async(
             t.deepEqual(context.newTemplate, context.template, 'set context.newTemplate');
             t.deepEqual(context.configNames, ['config'], 'set context.configNames');
             t.ok(context.create, 'context.create is set to true');
-            template.read.restore();
+            Template.read.restore();
             Lookup.configurations.restore();
             t.end();
         }
     });
 
-    commands.operations.createPreamble(context);
+    await Operations.createPreamble(context);
 });
 
-test('[commands.operations.selectConfig] force-mode', async(t) => {
+test('[Operations.selectConfig] force-mode', async(t) => {
     sinon.stub(Prompt, 'configuration').callsFake(() => {
         t.fail('should not prompt');
         throw new Error('failure');
@@ -2039,10 +2060,10 @@ test('[commands.operations.selectConfig] force-mode', async(t) => {
         }
     });
 
-    commands.operations.selectConfig(context);
+    await Operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] new config', async(t) => {
+test('[Operations.selectConfig] new config', async(t) => {
     sinon.stub(Prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('New configuration');
@@ -2058,10 +2079,10 @@ test('[commands.operations.selectConfig] new config', async(t) => {
         }
     });
 
-    commands.operations.selectConfig(context);
+    await Operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] saved config', async(t) => {
+test('[Operations.selectConfig] saved config', async(t) => {
     sinon.stub(Prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('config');
@@ -2077,10 +2098,10 @@ test('[commands.operations.selectConfig] saved config', async(t) => {
         }
     });
 
-    commands.operations.selectConfig(context);
+    await Operations.selectConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, no default', async(t) => {
+test('[Operations.loadConfig] no saved config, no default', async(t) => {
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
@@ -2089,10 +2110,10 @@ test('[commands.operations.loadConfig] no saved config, no default', async(t) =>
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, has default', async(t) => {
+test('[Operations.loadConfig] no saved config, has default', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake((s3url) => {
         t.equal(s3url, 's3://my-bucket/my-default.cfn.json', 'requested correct configuration');
         return Promise.resolve({ default: 'configuration' });
@@ -2108,10 +2129,10 @@ test('[commands.operations.loadConfig] no saved config, has default', async(t) =
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] bucket not found', async(t) => {
+test('[Operations.loadConfig] bucket not found', async(t) => {
     sinon.stub(Lookup, 'configuration').callsFake(() => {
         throw new Lookup.BucketNotFoundError('failure');
     });
@@ -2126,10 +2147,10 @@ test('[commands.operations.loadConfig] bucket not found', async(t) => {
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] config not found', async(t) => {
+test('[Operations.loadConfig] config not found', async(t) => {
     sinon.stub(Lookup, 'configuration').callsFake(() => {
         throw new Lookup.ConfigurationNotFoundError('failure');
     });
@@ -2144,10 +2165,10 @@ test('[commands.operations.loadConfig] config not found', async(t) => {
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] invalid config', async(t) => {
+test('[Operations.loadConfig] invalid config', async(t) => {
     sinon.stub(Lookup, 'configuration').callsFake(() => {
         throw new Lookup.InvalidConfigurationError('failure');
     });
@@ -2162,10 +2183,10 @@ test('[commands.operations.loadConfig] invalid config', async(t) => {
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] failed to load config', async(t) => {
+test('[Operations.loadConfig] failed to load config', async(t) => {
     sinon.stub(Lookup, 'configuration').callsFake(() => {
         throw new Lookup.S3Error('failure');
     });
@@ -2180,10 +2201,10 @@ test('[commands.operations.loadConfig] failed to load config', async(t) => {
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] success', async(t) => {
+test('[Operations.loadConfig] success', async(t) => {
     sinon.stub(Lookup, 'configuration').callsFake((name, bucket, config) => {
         t.equal(name, context.baseName, 'expected stack name');
         t.equal(bucket, context.configBucket, 'expected config bucket');
@@ -2201,10 +2222,10 @@ test('[commands.operations.loadConfig] success', async(t) => {
         }
     });
 
-    commands.operations.loadConfig(context);
+    await Operations.loadConfig(context);
 });
 
-test('[commands.operations.confirmCreate] force-mode', async(t) => {
+test('[Operations.confirmCreate] force-mode', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake(() => {
         t.fail('should not prompt');
         throw new Error('failure');
@@ -2219,10 +2240,10 @@ test('[commands.operations.confirmCreate] force-mode', async(t) => {
         }
     });
 
-    commands.operations.confirmCreate(context);
+    await Operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] reject', async(t) => {
+test('[Operations.confirmCreate] reject', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
@@ -2236,10 +2257,10 @@ test('[commands.operations.confirmCreate] reject', async(t) => {
         }
     });
 
-    commands.operations.confirmCreate(context);
+    await Operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] accept', async(t) => {
+test('[Operations.confirmCreate] accept', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to create the stack?', 'expected message');
         return Promise.resolve(true);
@@ -2254,10 +2275,10 @@ test('[commands.operations.confirmCreate] accept', async(t) => {
         }
     });
 
-    commands.operations.confirmCreate(context);
+    await Operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmDelete] force-mode', async(t) => {
+test('[Operations.confirmDelete] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
@@ -2266,10 +2287,10 @@ test('[commands.operations.confirmDelete] force-mode', async(t) => {
         }
     });
 
-    commands.operations.confirmDelete(context);
+    await Operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] reject', async(t) => {
+test('[Operations.confirmDelete] reject', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?');
         t.equal(defaultValue, false);
@@ -2284,10 +2305,10 @@ test('[commands.operations.confirmDelete] reject', async(t) => {
         }
     });
 
-    commands.operations.confirmDelete(context);
+    await Operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] accept', async(t) => {
+test('[Operations.confirmDelete] accept', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?', 'expected message');
         t.equal(defaultValue, false);
@@ -2302,10 +2323,10 @@ test('[commands.operations.confirmDelete] accept', async(t) => {
         }
     });
 
-    commands.operations.confirmDelete(context);
+    await Operations.confirmDelete(context);
 });
 
-test('[commands.operations.deleteStack] failure', async(t) => {
+test('[Operations.deleteStack] failure', async(t) => {
     sinon.stub(Actions, 'delete').callsFake(() => {
         throw new Actions.CloudFormationError('failure');
     });
@@ -2319,10 +2340,10 @@ test('[commands.operations.deleteStack] failure', async(t) => {
         }
     });
 
-    commands.operations.deleteStack(context);
+    await Operations.deleteStack(context);
 });
 
-test('[commands.operations.deleteStack] success', async(t) => {
+test('[Operations.deleteStack] success', async(t) => {
     sinon.stub(Actions, 'delete').callsFake((name, region) => {
         t.equal(name, context.stackName, 'deleted expected stack');
         t.equal(region, context.stackRegion, 'deleted in expected region');
@@ -2337,10 +2358,10 @@ test('[commands.operations.deleteStack] success', async(t) => {
         }
     });
 
-    commands.operations.deleteStack(context);
+    await Operations.deleteStack(context);
 });
 
-test('[commands.operations.monitorStack] failure', async(t) => {
+test('[Operations.monitorStack] failure', async(t) => {
     sinon.stub(Actions, 'monitor').callsFake(() => {
         throw new Actions.CloudFormationError('failure');
     });
@@ -2353,10 +2374,10 @@ test('[commands.operations.monitorStack] failure', async(t) => {
         }
     });
 
-    commands.operations.monitorStack(context);
+    await Operations.monitorStack(context);
 });
 
-test('[commands.operations.monitorStack] success', async(t) => {
+test('[Operations.monitorStack] success', async(t) => {
     sinon.stub(Actions, 'monitor').callsFake((name, region) => {
         t.equal(name, context.stackName, 'monitor expected stack');
         t.equal(region, context.stackRegion, 'monitor in expected region');
@@ -2371,11 +2392,11 @@ test('[commands.operations.monitorStack] success', async(t) => {
         }
     });
 
-    commands.operations.monitorStack(context);
+    await Operations.monitorStack(context);
 });
 
-test('[commands.operations.getOldParameters] missing stack', async(t) => {
-    sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
+test('[Operations.getOldParameters] missing stack', async(t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
         throw new Lookup.StackNotFoundError('failure');
     });
 
@@ -2388,10 +2409,10 @@ test('[commands.operations.getOldParameters] missing stack', async(t) => {
         }
     });
 
-    commands.operations.getOldParameters(context);
+    await Operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] failed to lookup stack', async(t) => {
+test('[Operations.getOldParameters] failed to lookup stack', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake(() => {
         throw new Lookup.CloudFormationError('failure');
     });
@@ -2405,10 +2426,10 @@ test('[commands.operations.getOldParameters] failed to lookup stack', async(t) =
         }
     });
 
-    commands.operations.getOldParameters(context);
+    await Operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] success', async(t) => {
+test('[Operations.getOldParameters] success', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
         t.equal(name, context.stackName, 'lookup expected stack');
         t.equal(region, context.stackRegion, 'lookup in expected region');
@@ -2424,10 +2445,10 @@ test('[commands.operations.getOldParameters] success', async(t) => {
         }
     });
 
-    commands.operations.getOldParameters(context);
+    await Operations.getOldParameters(context);
 });
 
-test('[commands.operations.promptSaveConfig]', async(t) => {
+test('[Operations.promptSaveConfig]', async(t) => {
     sinon.stub(Prompt, 'input').callsFake((message, def) => {
         t.equal(message, 'Name for saved configuration:', 'expected prompt');
         t.equal(def, context.suffix, 'expected default value');
@@ -2444,10 +2465,10 @@ test('[commands.operations.promptSaveConfig]', async(t) => {
         }
     });
 
-    commands.operations.promptSaveConfig(context);
+    await Operations.promptSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] reject', async(t) => {
+test('[Operations.confirmSaveConfig] reject', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
@@ -2461,10 +2482,10 @@ test('[commands.operations.confirmSaveConfig] reject', async(t) => {
         }
     });
 
-    commands.operations.confirmSaveConfig(context);
+    await Operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] accept', async(t) => {
+test('[Operations.confirmSaveConfig] accept', async(t) => {
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to save this configuration as "hello"?', 'expected message');
         return Promise.resolve(true);
@@ -2480,10 +2501,10 @@ test('[commands.operations.confirmSaveConfig] accept', async(t) => {
         }
     });
 
-    commands.operations.confirmSaveConfig(context);
+    await Operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.saveConfig] bucket not found', async(t) => {
+test('[Operations.saveConfig] bucket not found', async(t) => {
     sinon.stub(Actions, 'saveConfiguration').callsFake(() => {
         throw new Actions.BucketNotFoundError('failure');
     });
@@ -2499,10 +2520,10 @@ test('[commands.operations.saveConfig] bucket not found', async(t) => {
         }
     });
 
-    commands.operations.saveConfig(context);
+    await Operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] failure', async(t) => {
+test('[Operations.saveConfig] failure', async(t) => {
     sinon.stub(Actions, 'saveConfiguration').callsFake(() => {
         throw new Actions.S3Error('failure');
     });
@@ -2518,10 +2539,10 @@ test('[commands.operations.saveConfig] failure', async(t) => {
         }
     });
 
-    commands.operations.saveConfig(context);
+    await Operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] success', async(t) => {
+test('[Operations.saveConfig] success', async(t) => {
     sinon.stub(Actions, 'saveConfiguration').callsFake((baseName, stackName, stackRegion, bucket, parameters, kms) => {
         t.equal(baseName, context.baseName, 'save under correct stack name');
         t.equal(stackName, context.stackName, 'save under correct stack name');
@@ -2542,10 +2563,10 @@ test('[commands.operations.saveConfig] success', async(t) => {
         }
     });
 
-    commands.operations.saveConfig(context);
+    await Operations.saveConfig(context);
 });
 
-test('[commands.operations.mergeMetadata]', async(t) => {
+test('[Operations.mergeMetadata]', async(t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
@@ -2561,10 +2582,10 @@ test('[commands.operations.mergeMetadata]', async(t) => {
             t.end();
         }
     });
-    commands.operations.mergeMetadata(context);
+    await Operations.mergeMetadata(context);
 });
 
-test('[commands.operations.mergeMetadata] error', async(t) => {
+test('[Operations.mergeMetadata] error', async(t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template', Metadata: { LastDeploy: 'jane' } },
@@ -2579,5 +2600,5 @@ test('[commands.operations.mergeMetadata] error', async(t) => {
             t.end();
         }
     });
-    commands.operations.mergeMetadata(context);
+    await Operations.mergeMetadata(context);
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -800,7 +800,7 @@ test('[Operations.getMasterConfig] failed', async(t) => {
 
         t.fail();
     } catch (err) {
-        t.equals(err instanceof Error);
+        t.ok(err instanceof Error);
     }
 
     Lookup.defaultConfiguration.restore();
@@ -1135,8 +1135,6 @@ test('[Operations.confirmParameters] preapproved', async(t) => {
 });
 
 test('[Operations.confirmParameters] rejected', async(t) => {
-    t.plan(2);
-
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, ' {\n\x1b[31m-  old: "parameters"\x1b[39m\n\x1b[32m+  new: "parameterz"\x1b[39m\n }\n\nAccept parameter changes?', 'prompted appropriate message');
         return Promise.resolve(false);
@@ -1160,8 +1158,6 @@ test('[Operations.confirmParameters] rejected', async(t) => {
 });
 
 test('[Operations.confirmParameters] accepted', async(t) => {
-    t.plan(2);
-
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, ' {\n\x1b[31m-  old: "parameters"\x1b[39m\n\x1b[32m+  new: "parameters"\x1b[39m\n }\n\nAccept parameter changes?', 'prompted appropriate message');
         return Promise.resolve(true);
@@ -1255,8 +1251,6 @@ test('[Operations.confirmTemplate] preapproved', async(t) => {
 });
 
 test('[Operations.confirmTemplate] rejected', async(t) => {
-    t.plan(2);
-
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(
             message,
@@ -1283,8 +1277,6 @@ test('[Operations.confirmTemplate] rejected', async(t) => {
 });
 
 test('[Operations.confirmTemplate] accepted', async(t) => {
-    t.plan(2);
-
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, '\x1B[90m {\n\x1B[39m\x1B[31m-"old": "template"\n\x1B[39m\x1B[32m+"new": "template"\n\x1B[39m\x1B[90m }\x1B[39m\nAccept template changes?', 'prompted appropriate message');
         return Promise.resolve(true);
@@ -1305,8 +1297,6 @@ test('[Operations.confirmTemplate] accepted', async(t) => {
 });
 
 test('[Operations.confirmTemplate] lengthy diff, first unchanged section ignored', async(t) => {
-    t.plan(2);
-
     sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, '\x1B[90m {\n "a": "lines",\n "aa": "lines",\n\x1B[39m\x1B[31m-"and": "will change too",\n\x1B[39m\x1B[32m+"and": "has changed",\n\x1B[39m\x1B[90m "b": "lines",\n "ba": "lines",\n "c": "lines",\n\x1B[39m\x1B[90m\n---------------------------------------------\n\n\x1B[39m\x1B[90m "r": "lines",\n "s": "lines",\n "t": "lines",\n\x1B[39m\x1B[31m-"this": "will change",\n\x1B[39m\x1B[32m+"this": "has changed",\n\x1B[39m\x1B[90m "u": "lines",\n "v": "lines"\n }\x1B[39m\nAccept template changes?', 'prompted appropriate message');
         return Promise.resolve(true);
@@ -1510,8 +1500,6 @@ test('[Operations.validateTemplate] invalid', async(t) => {
 });
 
 test('[Operations.validateTemplate] valid', async(t) => {
-    t.plan(3);
-
     const context = new CommandContext(opts, 'testing', []);
 
     sinon.stub(Actions, 'validate').callsFake((region, url) => {
@@ -1576,8 +1564,6 @@ test('[Operations.validateParametersHook] hook error', async(t) => {
 });
 
 test('[Operations.validateParametersHook] hook success', async(t) => {
-    t.plan(2);
-
     try {
         const context = new CommandContext(opts, 'testing', []);
         context.overrides = {
@@ -1616,8 +1602,6 @@ test('[Operations.beforeUpdateHook] hook error', async(t) => {
 });
 
 test('[Operations.beforeUpdateHook] hook success', async(t) => {
-    t.plan(2);
-
     try {
         const context = new CommandContext(opts, 'testing', []);
         context.overrides = {
@@ -1656,8 +1640,6 @@ test('[Operations.getChangeset] failure', async(t) => {
 });
 
 test('[Operations.getChangeset] success', async(t) => {
-    t.plan(8);
-
     const details = { changeset: 'details' };
 
     const context = new CommandContext(opts, 'testing', []);
@@ -1692,8 +1674,6 @@ test('[Operations.getChangeset] success', async(t) => {
 });
 
 test('[Operations.getChangesetCreate] success', async(t) => {
-    t.plan(1);
-
     sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
         t.equals(changeSetType, 'CREATE', 'has changeSetType');
         return Promise.resolve();
@@ -1712,8 +1692,6 @@ test('[Operations.getChangesetCreate] success', async(t) => {
 });
 
 test('[Operations.getChangesetUpdate] success', async(t) => {
-    t.plan(1);
-
     sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
         t.equals(changeSetType, 'UPDATE', 'has changeSetType');
         return Promise.resolve();
@@ -1769,7 +1747,7 @@ test('[Operations.confirmChangeset] rejected', async(t) => {
 
         await Operations.confirmChangeset(context);
     } catch (err) {
-        t.equals(err.message, ''); //TODO
+        t.equals(err.message, 'aborted');
     }
 
     Prompt.confirm.restore();
@@ -1777,8 +1755,6 @@ test('[Operations.confirmChangeset] rejected', async(t) => {
 });
 
 test('[Operations.confirmChangeset] acccepted', async(t) => {
-    t.plan(3);
-
     sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, '\n\n\nAccept changes and update the stack?', 'expected message');
         t.equal(defaultValue, false);
@@ -1870,8 +1846,6 @@ test('[Operations.executeChangeSet] not executable', async(t) => {
 });
 
 test('[Operations.executeChangeSet] success', async(t) => {
-    t.plan(4);
-
     const context = new CommandContext(opts, 'testing', []);
 
     sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -3,11 +3,11 @@
 const path = require('path');
 const test = require('tape');
 const sinon = require('sinon');
-const commands = require('../lib/commands');
-const prompt = require('../lib/prompt');
-const actions = require('../lib/actions');
-const lookup = require('../lib/lookup');
-const template = require('../lib/template');
+const Commands = require('../lib/commands');
+const Prompt = require('../lib/prompt');
+const Actions = require('../lib/actions');
+const Lookup = require('../lib/lookup');
+const Template = require('../lib/template');
 
 const opts = {
     name: 'my-stack',

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -20,7 +20,7 @@ const opts = {
     templateBucket: 'my-template-bucket'
 };
 
-test('[commands.create] no overrides', async (t) => {
+test('[commands.create] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -37,7 +37,7 @@ test('[commands.create] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.create] with overrides', async (t) => {
+test('[commands.create] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -55,7 +55,7 @@ test('[commands.create] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.create] with template object', async (t) => {
+test('[commands.create] with template object', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -72,7 +72,7 @@ test('[commands.create] with template object', async (t) => {
     t.end();
 });
 
-test('[commands.update] no overrides', async (t) => {
+test('[commands.update] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -90,7 +90,7 @@ test('[commands.update] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides', async (t) => {
+test('[commands.update] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -107,7 +107,7 @@ test('[commands.update] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with multiple overrides', async (t) => {
+test('[commands.update] with multiple overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -124,7 +124,7 @@ test('[commands.update] with multiple overrides', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters', async (t) => {
+test('[commands.update] with overrides.skipConfirmParameters', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -142,7 +142,7 @@ test('[commands.update] with overrides.skipConfirmParameters', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmTemplate', async (t) => {
+test('[commands.update] with overrides.skipConfirmTemplate', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -159,7 +159,7 @@ test('[commands.update] with overrides.skipConfirmTemplate', async (t) => {
     t.end();
 });
 
-test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async (t) => {
+test('[commands.update] with overrides.skipConfirmParameters and overrides.skipConfirmTemplate', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -176,7 +176,7 @@ test('[commands.update] with overrides.skipConfirmParameters and overrides.skipC
     t.end();
 });
 
-test('[commands.update] with template object', async (t) => {
+test('[commands.update] with template object', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -194,7 +194,7 @@ test('[commands.update] with template object', async (t) => {
     t.end();
 });
 
-test('[commands.delete] no overrides', async (t) => {
+test('[commands.delete] no overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -211,7 +211,7 @@ test('[commands.delete] no overrides', async (t) => {
     t.end();
 });
 
-test('[commands.delete] with overrides', async (t) => {
+test('[commands.delete] with overrides', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -228,7 +228,7 @@ test('[commands.delete] with overrides', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/o resources', async (t) => {
+test('[commands.info] success w/o resources', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -249,7 +249,7 @@ test('[commands.info] success w/o resources', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/ resources', async (t) => {
+test('[commands.info] success w/ resources', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -270,7 +270,7 @@ test('[commands.info] success w/ resources', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/o decrypt', async (t) => {
+test('[commands.info] success w/o decrypt', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -291,7 +291,7 @@ test('[commands.info] success w/o decrypt', async (t) => {
     t.end();
 });
 
-test('[commands.info] success w/ decrypt', async (t) => {
+test('[commands.info] success w/ decrypt', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack-testing', 'lookup.info expected stack name');
         t.equal(region, 'us-east-1', 'lookup.info expected region');
@@ -312,7 +312,7 @@ test('[commands.info] success w/ decrypt', async (t) => {
     t.end();
 });
 
-test('[commands.info] null provided as suffix', async (t) => {
+test('[commands.info] null provided as suffix', async(t) => {
     sinon.stub(Lookup, 'info').callsFake((name, region, resources, decrypt) => {
         t.equal(name, 'my-stack', 'no trailing - on stack name');
         return Promise.resolve();
@@ -330,7 +330,7 @@ test('[commands.info] null provided as suffix', async (t) => {
     t.end();
 });
 
-test('[commands.save] kms-mode', async (t) => {
+test('[commands.save] kms-mode', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -346,7 +346,7 @@ test('[commands.save] kms-mode', async (t) => {
     t.end();
 });
 
-test('[commands.save] not kms-mode', async (t) => {
+test('[commands.save] not kms-mode', async(t) => {
     const cmd = new Commands(opts, true);
 
     try {
@@ -439,11 +439,11 @@ test('[commands.commandContext] context.diffs', async(t) => {
     t.end();
 });
 
-test('[commands.commandContext] aborts', async (t) => {
+test('[commands.commandContext] aborts', async(t) => {
 
     try {
         const ops = [
-            () => { throw new Error('aborted') }
+            () => { throw new Error('aborted'); }
         ];
 
         const context = new CommandContext(opts, 'testing', ops);
@@ -458,7 +458,7 @@ test('[commands.commandContext] aborts', async (t) => {
     t.end();
 });
 
-test('[commands.commandContext] aborts with error', async (t) => {
+test('[commands.commandContext] aborts with error', async(t) => {
     try {
         const ops = [
             () => { throw new Error('failure'); }
@@ -475,7 +475,7 @@ test('[commands.commandContext] aborts with error', async (t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] no template', async (t) => {
+test('[commands.operations.updatePreamble] no template', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake(() => {
         return Promise.resolve();
     });
@@ -500,7 +500,7 @@ test('[commands.operations.updatePreamble] no template', async (t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] templatePath not found', async (t) => {
+test('[commands.operations.updatePreamble] templatePath not found', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
         return Promise.resolve();
     });
@@ -527,7 +527,7 @@ test('[commands.operations.updatePreamble] templatePath not found', async (t) =>
     t.end();
 });
 
-test('[commands.operations.updatePreamble] template invalid', async (t) => {
+test('[commands.operations.updatePreamble] template invalid', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         throw new Template.InvalidTemplateError('failure');
     });
@@ -557,7 +557,7 @@ test('[commands.operations.updatePreamble] template invalid', async (t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] stack not found for parameters', async (t) => {
+test('[commands.operations.updatePreamble] stack not found for parameters', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -588,7 +588,7 @@ test('[commands.operations.updatePreamble] stack not found for parameters', asyn
     t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack parameters', async (t) => {
+test('[commands.operations.updatePreamble] failure getting stack parameters', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -620,7 +620,7 @@ test('[commands.operations.updatePreamble] failure getting stack parameters', as
 
 });
 
-test('[commands.operations.updatePreamble] stack not found for template', async (t) => {
+test('[commands.operations.updatePreamble] stack not found for template', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -651,7 +651,7 @@ test('[commands.operations.updatePreamble] stack not found for template', async 
     t.end();
 });
 
-test('[commands.operations.updatePreamble] failure getting stack template', async (t) => {
+test('[commands.operations.updatePreamble] failure getting stack template', async(t) => {
     sinon.stub(Template, 'read').callsFake(() => {
         return Promise.resolve();
     });
@@ -682,7 +682,7 @@ test('[commands.operations.updatePreamble] failure getting stack template', asyn
     t.end();
 });
 
-test('[commands.operations.updatePreamble] success', async (t) => {
+test('[commands.operations.updatePreamble] success', async(t) => {
     sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
@@ -717,7 +717,7 @@ test('[commands.operations.updatePreamble] success', async (t) => {
     t.end();
 });
 
-test('[commands.operations.updatePreamble] success with template object', async (t) => {
+test('[commands.operations.updatePreamble] success with template object', async(t) => {
     sinon.stub(Lookup, 'parameters').callsFake(() => {
         return Promise.resolve({ old: 'parameters' });
     });
@@ -744,7 +744,7 @@ test('[commands.operations.updatePreamble] success with template object', async 
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] success', async (t) => {
+test('[commands.operations.getMasterConfig] success', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ old: 'fresh' });
     });
@@ -765,156 +765,155 @@ test('[commands.operations.getMasterConfig] success', async (t) => {
     t.end();
 });
 
-test('[commands.operations.getMasterConfig] no-op', async (t) => {
+test('[commands.operations.getMasterConfig] no-op', async(t) => {
     sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
         return Promise.resolve({ old: 'fresh' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        overrides: {},
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.oldParameters, { old: 'stale' }, 'context.oldParameters stays the same');
-            Lookup.defaultConfiguration.restore();
-            t.end();
-        },
-        abort: function(err) {
-            t.ifError(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = {},
+        context.oldParameters = { old: 'stale' };
 
-    context.oldParameters = { old: 'stale' };
-    commands.operations.getMasterConfig(context);
+        await Operations.getMasterConfig(context);
+
+        t.deepEqual(context.oldParameters, { old: 'stale' }, 'context.oldParameters stays the same');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Lookup.defaultConfiguration.restore();
+    t.end();
+
 });
 
-test('[commands.operations.getMasterConfig] failed', async (t) => {
-
-    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
-        callback(new Error(), {});
+test('[commands.operations.getMasterConfig] failed', async(t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
+        throw new Error();
     });
 
-    const context = Object.assign({}, basicContext, {
-        overrides: { masterConfig: 's3://unchill.cfn.json' },
-        next: function() {
-            t.fail('should not call next');
-        },
-        abort: function() {
-            Lookup.defaultConfiguration.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = { masterConfig: 's3://unchill.cfn.json' },
+        context.oldParameters = { old: 'stale' };
+        await Operations.getMasterConfig(context);
 
-    context.oldParameters = { old: 'stale' };
-    commands.operations.getMasterConfig(context);
+        t.fail();
+    } catch (err) {
+        t.equals(err instanceof Error);
+    }
+
+    Lookup.defaultConfiguration.restore();
+    t.end();
 });
 
-test('[commands.operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', async (t) => {
-
-    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
-        callback(null, { bingo: 'fresh' });
+test('[commands.operations.getMasterConfig] no matching oldParameters does not put masterConfig keys into oldParameters for better looking diff at the end', async(t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
+        return Promise.resolve({ bingo: 'fresh' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        overrides: { masterConfig: 's3://chill.cfn.json' },
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.oldParameters, { old: 'stale' }, 'leaves context.oldParameters alone');
-            Lookup.defaultConfiguration.restore();
-            t.end();
-        },
-        abort: function(err) {
-            t.ifError(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = { masterConfig: 's3://chill.cfn.json' },
 
-    context.oldParameters = { old: 'stale' };
-    commands.operations.getMasterConfig(context);
+        context.oldParameters = { old: 'stale' };
+        await Operations.getMasterConfig(context);
+
+        t.deepEqual(context.oldParameters, { old: 'stale' }, 'leaves context.oldParameters alone');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Lookup.defaultConfiguration.restore();
+    t.end();
 });
 
-test('[commands.operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', async (t) => {
-
-    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3Url, callback) {
-        callback(null, { old: 'fresh' });
+test('[commands.operations.getMasterConfig] adding a newParameter that matches masterConfig parameter does not get overwritten, so that user is intentional in adding newParameters', async(t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake(() => {
+        return Promise.resolve({ old: 'fresh' });
     });
 
-    const context = Object.assign({}, basicContext, {
-        overrides: { masterConfig: 's3://chill.cfn.json' },
-        next: function() {
-            t.pass('calls next()');
-            t.deepEqual(context.oldParameters, { hello: 'goodbye' }, 'no matching keys between oldParameters and masterConfig, no oldParameters are replaced');
-            t.deepEqual(context.newTemplate.Parameters, { old: 'special whale' }, 'newParameters are not replaced despite matching keys');
-            Lookup.defaultConfiguration.restore();
-            t.end();
-        },
-        abort: function(err) {
-            t.ifError(err, 'failed');
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.overrides = { masterConfig: 's3://chill.cfn.json' },
 
-    context.oldParameters = { hello: 'goodbye' };
-    context.newTemplate = {};
-    context.newTemplate.Parameters = { old: 'special whale' };
-    commands.operations.getMasterConfig(context);
+        context.oldParameters = { hello: 'goodbye' };
+        context.newTemplate = {};
+        context.newTemplate.Parameters = { old: 'special whale' };
+        commands.operations.getMasterConfig(context);
+
+        t.deepEqual(context.oldParameters, { hello: 'goodbye' }, 'no matching keys between oldParameters and masterConfig, no oldParameters are replaced');
+        t.deepEqual(context.newTemplate.Parameters, { old: 'special whale' }, 'newParameters are not replaced despite matching keys');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Lookup.defaultConfiguration.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] force-mode', async (t) => {
-    sinon.stub(template, 'questions').callsFake(function() {
+test('[commands.operations.promptParameters] force-mode', async(t) => {
+    sinon.stub(Template, 'questions').callsFake(() => {
         t.fail('should not build questions');
     });
 
-    const context = Object.assign({}, basicContext, {
-        newTemplate: { Parameters: { old: {}, new: {} } },
-        oldParameters: { old: 'parameters', extra: 'value' },
-        overrides: { force: true },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.deepEqual(context.newParameters, { old: 'parameters' }, 'sets new parameters to old values, excluding values not present in template');
-            t.notOk(context.newParameters.new, 'does not provide a parameter value if no default for it was found');
-            template.questions.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.newTemplate = { Parameters: { old: {}, new: {} } },
+        context.oldParameters = { old: 'parameters', extra: 'value' },
+        context.overrides = { force: true },
 
-    commands.operations.promptParameters(context);
+        await Operations.promptParameters(context);
+
+        t.deepEqual(context.newParameters, { old: 'parameters' }, 'sets new parameters to old values, excluding values not present in template');
+        t.notOk(context.newParameters.new, 'does not provide a parameter value if no default for it was found');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Template.questions.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] not force-mode', async (t) => {
+test('[commands.operations.promptParameters] not force-mode', async(t) => {
     const questions = { parameter: 'questions' };
     const answers = { parameter: 'answers' };
 
-    sinon.stub(template, 'questions').callsFake(function(template, overrides) {
+    sinon.stub(Template, 'questions').callsFake((template, overrides) => {
         t.deepEqual(template, { new: 'template' }, 'builds questions for new template');
         t.deepEqual(overrides, { defaults: { old: 'parameters' }, kmsKeyId: undefined, region: 'us-east-1' }, 'uses old parameters as default values');
         return questions;
     });
 
-    sinon.stub(prompt, 'parameters').callsFake((question) => {
+    sinon.stub(Prompt, 'parameters').callsFake((question) => {
         t.deepEqual(question, questions, 'prompts for derived questions');
         return Promise.resolve(answers);
     });
 
-    const context = Object.assign({}, basicContext, {
-        newTemplate: { new: 'template' },
-        oldParameters: { old: 'parameters' },
-        next: function(err) {
-            t.ifError(err, 'success');
-            t.deepEqual(context.newParameters, answers, 'sets new parameters to prompt responses');
-            template.questions.restore();
-            prompt.parameters.restore();
-            t.end();
-        }
-    });
+    try {
+        const context = new CommandContext(opts, 'testing', []);
+        context.newTemplate = { new: 'template' },
+        context.oldParameters = { old: 'parameters' },
 
-    commands.operations.promptParameters(context);
+        Operations.promptParameters(context);
+
+        t.deepEqual(context.newParameters, answers, 'sets new parameters to prompt responses');
+    } catch (err) {
+        t.error(err);
+    }
+
+    Template.questions.restore();
+    Prompt.parameters.restore();
+    t.end();
 });
 
-test('[commands.operations.promptParameters] with parameter and kms overrides', async (t) => {
-    sinon.stub(template, 'questions').callsFake(function(template, overrides) {
+test('[commands.operations.promptParameters] with parameter and kms overrides', async(t) => {
+    sinon.stub(Template, 'questions').callsFake((template, overrides) => {
         t.deepEqual(overrides, { defaults: { old: 'overriden' }, kmsKeyId: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
         return { parameter: 'questions' };
     });
 
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve({ the: 'answers' });
     });
 
@@ -926,7 +925,7 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
         next: function(err) {
             t.ifError(err, 'success');
             template.questions.restore();
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -934,7 +933,7 @@ test('[commands.operations.promptParameters] with parameter and kms overrides', 
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] force-mode with no parameters in new template', async (t) => {
+test('[commands.operations.promptParameters] force-mode with no parameters in new template', async(t) => {
     const context = Object.assign({}, basicContext, {
         newTemplate: { new: 'template' },
         overrides: { force: true },
@@ -948,8 +947,8 @@ test('[commands.operations.promptParameters] force-mode with no parameters in ne
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] reject overrides that are not in old or new template', async (t) => {
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+test('[commands.operations.promptParameters] reject overrides that are not in old or new template', async(t) => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve({ some: 'answers' });
     });
 
@@ -960,7 +959,7 @@ test('[commands.operations.promptParameters] reject overrides that are not in ol
         next: function(err) {
             t.ifError(err, 'success');
             t.notOk(context.oldParameters.Born, 'excludes extraneous parameter override');
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -968,11 +967,11 @@ test('[commands.operations.promptParameters] reject overrides that are not in ol
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', async (t) => {
+test('[commands.operations.promptParameters] changesetParameters use previous value for unchanged parameter values', async(t) => {
     const oldParameters = { old: 'parameters', the: 'answers' };
     const newParameters = { old: 'newvalue', the: 'answers' };
 
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
@@ -984,7 +983,7 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.changesetParameters, [{ ParameterKey: 'old', ParameterValue: 'newvalue' }, { ParameterKey: 'the', UsePreviousValue: true }]);
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -992,11 +991,11 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', async (t) => {
+test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', async(t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
@@ -1008,7 +1007,7 @@ test('[commands.operations.promptParameters] changesetParameters does not set Us
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -1016,11 +1015,11 @@ test('[commands.operations.promptParameters] changesetParameters does not set Us
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', async (t) => {
+test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', async(t) => {
     const oldParameters = { beep: 'bop' };
     const newParameters = { beep: 'bop' };
 
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
@@ -1032,7 +1031,7 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', UsePreviousValue: true }]);
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -1040,11 +1039,11 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', async (t) => {
+test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', async(t) => {
     const oldParameters = { beep: 'boop' };
     const newParameters = { beep: 'boop' };
 
-    sinon.stub(prompt, 'parameters').callsFake(() => {
+    sinon.stub(Prompt, 'parameters').callsFake(() => {
         return Promise.resolve(newParameters);
     });
 
@@ -1058,7 +1057,7 @@ test('[commands.operations.promptParameters] do not set UsePreviousValue when cr
             t.ifError(err, 'success');
             t.ok(context.create, 'context.create is set to true');
             t.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
-            prompt.parameters.restore();
+            Prompt.parameters.restore();
             t.end();
         }
     });
@@ -1066,7 +1065,7 @@ test('[commands.operations.promptParameters] do not set UsePreviousValue when cr
     commands.operations.promptParameters(context);
 });
 
-test('[commands.operations.confirmParameters] force-mode', async (t) => {
+test('[commands.operations.confirmParameters] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         oldParameters: { old: 'parameters' },
@@ -1080,7 +1079,7 @@ test('[commands.operations.confirmParameters] force-mode', async (t) => {
     commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] no difference', async (t) => {
+test('[commands.operations.confirmParameters] no difference', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         newParameters: { old: 'parameters' },
@@ -1093,7 +1092,7 @@ test('[commands.operations.confirmParameters] no difference', async (t) => {
     commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] preapproved', async (t) => {
+test('[commands.operations.confirmParameters] preapproved', async(t) => {
     sinon.stub(console, 'log');
 
     const context = Object.assign({}, basicContext, {
@@ -1114,10 +1113,10 @@ test('[commands.operations.confirmParameters] preapproved', async (t) => {
     await commands.operations.confirmParameters(context);
 });
 
-test('[commands.operations.confirmParameters] rejected', async (t) => {
+test('[commands.operations.confirmParameters] rejected', async(t) => {
     t.plan(2);
 
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, ' {\n\x1b[31m-  old: "parameters"\x1b[39m\n\x1b[32m+  new: "parameterz"\x1b[39m\n }\n\nAccept parameter changes?', 'prompted appropriate message');
         return Promise.resolve(false);
     });
@@ -1131,16 +1130,16 @@ test('[commands.operations.confirmParameters] rejected', async (t) => {
         },
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     }));
 });
 
-test('[commands.operations.confirmParameters] accepted', async (t) => {
+test('[commands.operations.confirmParameters] accepted', async(t) => {
     t.plan(2);
 
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, ' {\n\x1b[31m-  old: "parameters"\x1b[39m\n\x1b[32m+  new: "parameters"\x1b[39m\n }\n\nAccept parameter changes?', 'prompted appropriate message');
         return Promise.resolve(true);
     });
@@ -1151,7 +1150,7 @@ test('[commands.operations.confirmParameters] accepted', async (t) => {
         overrides: {},
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         },
         abort: function() {
@@ -1160,7 +1159,7 @@ test('[commands.operations.confirmParameters] accepted', async (t) => {
     }));
 });
 
-test('[commands.operations.confirmTemplate] no difference', async (t) => {
+test('[commands.operations.confirmTemplate] no difference', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { old: 'template' },
@@ -1173,7 +1172,7 @@ test('[commands.operations.confirmTemplate] no difference', async (t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] undefined', async (t) => {
+test('[commands.operations.confirmTemplate] undefined', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { Parameters: { old: undefined } },
         newTemplate: { Parameters: {} },
@@ -1186,7 +1185,7 @@ test('[commands.operations.confirmTemplate] undefined', async (t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] force-mode', async (t) => {
+test('[commands.operations.confirmTemplate] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         oldTemplate: { old: 'template' },
         newTemplate: { new: 'template' },
@@ -1203,7 +1202,7 @@ test('[commands.operations.confirmTemplate] force-mode', async (t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] preapproved', async (t) => {
+test('[commands.operations.confirmTemplate] preapproved', async(t) => {
     sinon.stub(console, 'log');
 
     const context = Object.assign({}, basicContext, {
@@ -1229,10 +1228,10 @@ test('[commands.operations.confirmTemplate] preapproved', async (t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] rejected', async (t) => {
+test('[commands.operations.confirmTemplate] rejected', async(t) => {
     t.plan(2);
 
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(
             message,
             '\x1B[90m {\n\x1B[39m\x1B[31m-"old": "template"\n\x1B[39m\x1B[32m+"new": "template"\n\x1B[39m\x1B[90m }\x1B[39m\nAccept template changes?',
@@ -1251,17 +1250,17 @@ test('[commands.operations.confirmTemplate] rejected', async (t) => {
         },
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
         }
     });
 
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] accepted', async (t) => {
+test('[commands.operations.confirmTemplate] accepted', async(t) => {
     t.plan(2);
 
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, '\x1B[90m {\n\x1B[39m\x1B[31m-"old": "template"\n\x1B[39m\x1B[32m+"new": "template"\n\x1B[39m\x1B[90m }\x1B[39m\nAccept template changes?', 'prompted appropriate message');
         return Promise.resolve(true);
     });
@@ -1271,7 +1270,7 @@ test('[commands.operations.confirmTemplate] accepted', async (t) => {
         newTemplate: { new: 'template' },
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         },
         abort: function() {
@@ -1282,10 +1281,10 @@ test('[commands.operations.confirmTemplate] accepted', async (t) => {
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', async (t) => {
+test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', async(t) => {
     t.plan(2);
 
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, '\x1B[90m {\n "a": "lines",\n "aa": "lines",\n\x1B[39m\x1B[31m-"and": "will change too",\n\x1B[39m\x1B[32m+"and": "has changed",\n\x1B[39m\x1B[90m "b": "lines",\n "ba": "lines",\n "c": "lines",\n\x1B[39m\x1B[90m\n---------------------------------------------\n\n\x1B[39m\x1B[90m "r": "lines",\n "s": "lines",\n "t": "lines",\n\x1B[39m\x1B[31m-"this": "will change",\n\x1B[39m\x1B[32m+"this": "has changed",\n\x1B[39m\x1B[90m "u": "lines",\n "v": "lines"\n }\x1B[39m\nAccept template changes?', 'prompted appropriate message');
         return Promise.resolve(true);
     });
@@ -1369,7 +1368,7 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
         },
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         },
         abort: function() {
@@ -1380,23 +1379,23 @@ test('[commands.operations.confirmTemplate] lengthy diff, first unchanged sectio
     await commands.operations.confirmTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] bucket not found', async (t) => {
+test('[commands.operations.saveTemplate] bucket not found', async(t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
-    sinon.stub(actions, 'templateUrl').callsFake(function() {
+    sinon.stub(Actions, 'templateUrl').callsFake(() => {
         return url;
     });
 
-    sinon.stub(actions, 'saveTemplate').callsFake(function(url, template, callback) {
-        callback(new actions.BucketNotFoundError('failure'));
+    sinon.stub(Actions, 'saveTemplate').callsFake(() => {
+        throw new Actions.BucketNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof actions.BucketNotFoundError, 'expected error type');
+            t.ok(err instanceof Actions.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find template bucket: failure', 'expected error message');
-            actions.templateUrl.restore();
-            actions.saveTemplate.restore();
+            Actions.templateUrl.restore();
+            Actions.saveTemplate.restore();
             t.end();
         }
     });
@@ -1404,23 +1403,23 @@ test('[commands.operations.saveTemplate] bucket not found', async (t) => {
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] failed to save template', async (t) => {
+test('[commands.operations.saveTemplate] failed to save template', async(t) => {
     const url = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
-    sinon.stub(actions, 'templateUrl').callsFake(function() {
+    sinon.stub(Actions, 'templateUrl').callsFake(() => {
         return url;
     });
 
-    sinon.stub(actions, 'saveTemplate').callsFake(function(url, template, callback) {
-        callback(new actions.S3Error('failure'));
+    sinon.stub(Actions, 'saveTemplate').callsFake(() => {
+        throw new Actions.S3Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof actions.S3Error, 'expected error type');
+            t.ok(err instanceof Actions.S3Error, 'expected error type');
             t.equal(err.message, 'Failed to save template: failure', 'expected error message');
-            actions.templateUrl.restore();
-            actions.saveTemplate.restore();
+            Actions.templateUrl.restore();
+            Actions.saveTemplate.restore();
             t.end();
         }
     });
@@ -1428,20 +1427,21 @@ test('[commands.operations.saveTemplate] failed to save template', async (t) => 
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.saveTemplate] success', async (t) => {
+test('[commands.operations.saveTemplate] success', async(t) => {
     const templateUrl = 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json';
 
-    sinon.stub(actions, 'templateUrl').callsFake(function(bucket, region, suffix) {
+    sinon.stub(Actions, 'templateUrl').callsFake((bucket, region, suffix) => {
         t.equal(bucket, context.templateBucket, 'template url in proper bucket');
         t.equal(region, context.stackRegion, 'template url in proper region');
         t.equal(suffix, context.suffix, 'template url for correct suffix');
         return templateUrl;
     });
 
-    sinon.stub(actions, 'saveTemplate').callsFake(function(url, template, callback) {
+    sinon.stub(Actions, 'saveTemplate').callsFake((url, template) => {
         t.equal(url, templateUrl, 'saved to correct url');
         t.equal(template, '{\n  "new": "template"\n}', 'saved correct template');
-        callback();
+
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1449,8 +1449,8 @@ test('[commands.operations.saveTemplate] success', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.equal(context.templateUrl, templateUrl, 'sets template url');
-            actions.templateUrl.restore();
-            actions.saveTemplate.restore();
+            Actions.templateUrl.restore();
+            Actions.saveTemplate.restore();
             t.end();
         }
     });
@@ -1458,17 +1458,17 @@ test('[commands.operations.saveTemplate] success', async (t) => {
     commands.operations.saveTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] invalid', async (t) => {
-    sinon.stub(actions, 'validate').callsFake(function(region, url, callback) {
-        callback(new actions.CloudFormationError('failure'));
+test('[commands.operations.validateTemplate] invalid', async(t) => {
+    sinon.stub(Actions, 'validate').callsFake(() => {
+        throw new Actions.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         templateUrl: 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json',
         abort: function(err) {
-            t.ok(err instanceof actions.CloudFormationError, 'correct error type');
+            t.ok(err instanceof Actions.CloudFormationError, 'correct error type');
             t.equal(err.message, 'Invalid template: failure', 'expected error message');
-            actions.validate.restore();
+            Actions.validate.restore();
             t.end();
         }
     });
@@ -1476,13 +1476,13 @@ test('[commands.operations.validateTemplate] invalid', async (t) => {
     commands.operations.validateTemplate(context);
 });
 
-test('[commands.operations.validateTemplate] valid', async (t) => {
+test('[commands.operations.validateTemplate] valid', async(t) => {
     t.plan(3);
 
-    sinon.stub(actions, 'validate').callsFake(function(region, url, callback) {
+    sinon.stub(Actions, 'validate').callsFake((region, url) => {
         t.equal(region, context.stackRegion, 'validate in proper region');
         t.equal(url, context.templateUrl, 'validate proper template');
-        callback();
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1492,14 +1492,14 @@ test('[commands.operations.validateTemplate] valid', async (t) => {
         },
         next: function(err) {
             t.ifError(err, 'success');
-            actions.validate.restore();
+            Actions.validate.restore();
         }
     });
 
     commands.operations.validateTemplate(context);
 });
 
-test('[commands.operations.beforeUpdateHook] no hook', async (t) => {
+test('[commands.operations.beforeUpdateHook] no hook', async(t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1513,7 +1513,7 @@ test('[commands.operations.beforeUpdateHook] no hook', async (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.validateParametersHook] no hook', async (t) => {
+test('[commands.operations.validateParametersHook] no hook', async(t) => {
     const context = Object.assign({}, basicContext, {
         abort: function() {
             t.fail('failed');
@@ -1527,7 +1527,7 @@ test('[commands.operations.validateParametersHook] no hook', async (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook error', async (t) => {
+test('[commands.operations.validateParametersHook] hook error', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             validateParameters: function(context, callback) {
@@ -1546,7 +1546,7 @@ test('[commands.operations.validateParametersHook] hook error', async (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.validateParametersHook] hook success', async (t) => {
+test('[commands.operations.validateParametersHook] hook success', async(t) => {
     t.plan(2);
     const context = Object.assign({}, basicContext, {
         overrides: {
@@ -1566,7 +1566,7 @@ test('[commands.operations.validateParametersHook] hook success', async (t) => {
     commands.operations.validateParametersHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook error', async (t) => {
+test('[commands.operations.beforeUpdateHook] hook error', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: {
             beforeUpdate: function(context, callback) {
@@ -1585,7 +1585,7 @@ test('[commands.operations.beforeUpdateHook] hook error', async (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.beforeUpdateHook] hook success', async (t) => {
+test('[commands.operations.beforeUpdateHook] hook success', async(t) => {
     t.plan(2);
 
     const context = Object.assign({}, basicContext, {
@@ -1606,16 +1606,16 @@ test('[commands.operations.beforeUpdateHook] hook success', async (t) => {
     commands.operations.beforeUpdateHook(context);
 });
 
-test('[commands.operations.getChangeset] failure', async (t) => {
-    sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
-        callback(new actions.CloudFormationError('failure'));
+test('[commands.operations.getChangeset] failure', async(t) => {
+    sinon.stub(Actions, 'diff').callsFake(() => {
+        throw new Actions.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof actions.CloudFormationError, 'correct error type');
+            t.ok(err instanceof Actions.CloudFormationError, 'correct error type');
             t.equal(err.message, 'Failed to generate changeset: failure', 'expected error message');
-            actions.diff.restore();
+            Actions.diff.restore();
             t.end();
         },
         next: function() {
@@ -1626,19 +1626,19 @@ test('[commands.operations.getChangeset] failure', async (t) => {
     commands.operations.getChangeset(context);
 });
 
-test('[commands.operations.getChangeset] success', async (t) => {
+test('[commands.operations.getChangeset] success', async(t) => {
     t.plan(8);
 
     const details = { changeset: 'details' };
 
-    sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
+    sinon.stub(Actions, 'diff').callsFake((name, region, changeSetType, url, params, expand) => {
         t.equal(name, context.stackName, 'changeset for correct stack');
         t.equal(region, context.stackRegion, 'changeset in the correct region');
         t.equal(changeSetType, 'UPDATE', 'changeSetType set correctly');
         t.equal(url, context.templateUrl, 'changeset for the correct template');
         t.deepEqual(params, context.changesetParameters, 'changeset using changeset parameters');
         t.equal(expand, context.overrides.expand, 'changeset using override properties');
-        callback(null, details);
+        return Promise.resolve(details);
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1654,7 +1654,7 @@ test('[commands.operations.getChangeset] success', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.deepEqual(context.changeset, details, 'sets context.changeset');
-            actions.diff.restore();
+            Actions.diff.restore();
             t.end();
         }
     });
@@ -1662,12 +1662,12 @@ test('[commands.operations.getChangeset] success', async (t) => {
     commands.operations.getChangeset(context, 'UPDATE');
 });
 
-test('[commands.operations.getChangesetCreate] success', async (t) => {
+test('[commands.operations.getChangesetCreate] success', async(t) => {
     t.plan(1);
 
-    sinon.stub(commands.operations, 'getChangeset').callsFake(function(context, changeSetType) {
+    sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
         t.equals(changeSetType, 'CREATE', 'has changeSetType');
-        context.next();
+        return Promise.resolve();
     });
 
     const context = {
@@ -1680,12 +1680,12 @@ test('[commands.operations.getChangesetCreate] success', async (t) => {
     commands.operations.getChangesetCreate(context);
 });
 
-test('[commands.operations.getChangesetUpdate] success', async (t) => {
+test('[commands.operations.getChangesetUpdate] success', async(t) => {
     t.plan(1);
 
-    sinon.stub(commands.operations, 'getChangeset').callsFake(function(context, changeSetType) {
+    sinon.stub(Operations, 'getChangeset').callsFake((context, changeSetType) => {
         t.equals(changeSetType, 'UPDATE', 'has changeSetType');
-        context.next();
+        return Promise.resolve();
     });
 
     const context = {
@@ -1698,7 +1698,7 @@ test('[commands.operations.getChangesetUpdate] success', async (t) => {
     commands.operations.getChangesetUpdate(context);
 });
 
-test('[commands.operations.confirmChangeset] force-mode', async (t) => {
+test('[commands.operations.confirmChangeset] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function() {
@@ -1713,7 +1713,7 @@ test('[commands.operations.confirmChangeset] force-mode', async (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', async (t) => {
+test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTemplate', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { skipConfirmParameters: true, skipConfirmTemplate: true },
         next: function() {
@@ -1728,8 +1728,8 @@ test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTem
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] rejected', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
+test('[commands.operations.confirmChangeset] rejected', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(defaultValue, false);
         return Promise.resolve(false);
     });
@@ -1738,7 +1738,7 @@ test('[commands.operations.confirmChangeset] rejected', async (t) => {
         changeset: { changes: [] },
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -1746,10 +1746,10 @@ test('[commands.operations.confirmChangeset] rejected', async (t) => {
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] acccepted', async (t) => {
+test('[commands.operations.confirmChangeset] acccepted', async(t) => {
     t.plan(3);
 
-    sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, '\n\n\nAccept changes and update the stack?', 'expected message');
         t.equal(defaultValue, false);
         return Promise.resolve(true);
@@ -1762,15 +1762,15 @@ test('[commands.operations.confirmChangeset] acccepted', async (t) => {
         },
         next: function() {
             t.pass('success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
         }
     });
 
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] changeset formatting', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
+test('[commands.operations.confirmChangeset] changeset formatting', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Action  Name  Type  Replace\n------  ----  ----  -------\n\x1b[33mModify\x1b[39m  name  type  \x1b[31mtrue\x1b[39m   \n\x1b[32mAdd\x1b[39m     name  type  \x1b[32mfalse\x1b[39m  \n\x1b[31mRemove\x1b[39m  name  type  \x1b[32mfalse\x1b[39m  \n\nAccept changes and update the stack?', 'expected message (with colors)');
         t.equal(defaultValue, false);
         return Promise.resolve(true);
@@ -1789,7 +1789,7 @@ test('[commands.operations.confirmChangeset] changeset formatting', async (t) =>
         },
         next: function() {
             t.pass('success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -1797,17 +1797,17 @@ test('[commands.operations.confirmChangeset] changeset formatting', async (t) =>
     commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.executeChangeSet] failure', async (t) => {
-    sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
-        callback(new actions.CloudFormationError('failure'));
+test('[commands.operations.executeChangeSet] failure', async(t) => {
+    sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
+        throw new Actions.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         abort: function(err) {
-            t.ok(err instanceof actions.CloudFormationError, 'expected error type');
+            t.ok(err instanceof Actions.CloudFormationError, 'expected error type');
             t.equal(err.message, 'Failed to execute changeset: failure');
-            actions.executeChangeSet.restore();
+            Actions.executeChangeSet.restore();
             t.end();
         }
     });
@@ -1815,20 +1815,20 @@ test('[commands.operations.executeChangeSet] failure', async (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] not executable', async (t) => {
-    sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
-        const err = new actions.ChangeSetNotExecutableError('failure');
+test('[commands.operations.executeChangeSet] not executable', async(t) => {
+    sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
+        const err = new Actions.ChangeSetNotExecutableError('failure');
         err.execution = 'OBSOLETE';
         err.reason = 'outdated';
-        callback(err);
+        throw err;
     });
 
     const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         abort: function(err) {
-            t.ok(err instanceof actions.ChangeSetNotExecutableError, 'expected error type');
+            t.ok(err instanceof Actions.ChangeSetNotExecutableError, 'expected error type');
             t.equal(err.message, 'Status: OBSOLETE | Reason: outdated | failure', 'expected error message');
-            actions.executeChangeSet.restore();
+            Actions.executeChangeSet.restore();
             t.end();
         }
     });
@@ -1836,21 +1836,22 @@ test('[commands.operations.executeChangeSet] not executable', async (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.executeChangeSet] success', async (t) => {
+test('[commands.operations.executeChangeSet] success', async(t) => {
     t.plan(4);
 
-    sinon.stub(actions, 'executeChangeSet').callsFake(function(name, region, id, callback) {
+    sinon.stub(Actions, 'executeChangeSet').callsFake((name, region, id) => {
         t.equal(name, context.stackName, 'execute on proper stack');
         t.equal(region, context.stackRegion, 'execute in proper region');
         t.equal(id, context.changeset.id, 'execute proper changeset');
-        callback();
+
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
         changeset: { id: 'changeset:arn' },
         next: function() {
             t.pass('success');
-            actions.executeChangeSet.restore();
+            Actions.executeChangeSet.restore();
             t.end();
         }
     });
@@ -1858,9 +1859,9 @@ test('[commands.operations.executeChangeSet] success', async (t) => {
     commands.operations.executeChangeSet(context);
 });
 
-test('[commands.operations.createPreamble] no template', async (t) => {
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback();
+test('[commands.operations.createPreamble] no template', async(t) => {
+    sinon.stub(Lookup, 'configurations').callsFake(() => {
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1875,9 +1876,9 @@ test('[commands.operations.createPreamble] no template', async (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template not found', async (t) => {
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback();
+test('[commands.operations.createPreamble] template not found', async(t) => {
+    sinon.stub(Lookup, 'configurations').callsFake(() => {
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1893,13 +1894,13 @@ test('[commands.operations.createPreamble] template not found', async (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] template invalid', async (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback(new template.InvalidTemplateError('failure'));
+test('[commands.operations.createPreamble] template invalid', async(t) => {
+    sinon.stub(template, 'read').callsFake(() => {
+        throw new Template.InvalidTemplateError('failure');
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback();
+    sinon.stub(Lookup, 'configurations').callsFake(() => {
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1916,13 +1917,13 @@ test('[commands.operations.createPreamble] template invalid', async (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] config bucket not found', async (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.createPreamble] config bucket not found', async(t) => {
+    sinon.stub(template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback(new Lookup.BucketNotFoundError('failure'));
+    sinon.stub(Lookup, 'configurations').callsFake(() => {
+        throw new Lookup.BucketNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1939,13 +1940,13 @@ test('[commands.operations.createPreamble] config bucket not found', async (t) =
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] failed to read configurations', async (t) => {
-    sinon.stub(template, 'read').callsFake(function(templatePath, options, callback) {
-        callback();
+test('[commands.operations.createPreamble] failed to read configurations', async(t) => {
+    sinon.stub(Template, 'read').callsFake(() => {
+        return Promise.resolve();
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
-        callback(new Lookup.S3Error('failure'));
+    sinon.stub(Lookup, 'configurations').callsFake(() => {
+        throw new Lookup.S3Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1962,17 +1963,17 @@ test('[commands.operations.createPreamble] failed to read configurations', async
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success', async (t) => {
-    sinon.stub(template, 'read').callsFake(function(template, options, callback) {
+test('[commands.operations.createPreamble] success', async(t) => {
+    sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve('example.template.json'), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
-        callback(null, { new: 'template' });
+        return Promise.resolve({ new: 'template' });
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+    sinon.stub(Lookup, 'configurations').callsFake((name, bucket, region) => {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
-        callback(null, ['config']);
+        return Promise.resolve(['config']);
     });
 
     const context = Object.assign({}, basicContext, {
@@ -1992,17 +1993,17 @@ test('[commands.operations.createPreamble] success', async (t) => {
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.createPreamble] success with template object', async (t) => {
-    sinon.stub(template, 'read').callsFake(function(template, options, callback) {
+test('[commands.operations.createPreamble] success with template object', async(t) => {
+    sinon.stub(Template, 'read').callsFake((template, options) => {
         t.equal(template, path.resolve(context.template), 'read correct template path');
         t.deepEqual(options, { template: 'options' }, 'passed overrides.templateOptions');
-        callback(null, context.template);
+        return Promise.resolve(context.template);
     });
 
-    sinon.stub(Lookup, 'configurations').callsFake(function(name, bucket, region, callback) {
+    sinon.stub(Lookup, 'configurations').callsFake((name, bucket, region) => {
         t.equal(name, context.baseName, 'lookup correct stack configurations');
         t.equal(bucket, context.configBucket, 'lookup in correct bucket');
-        callback(null, ['config']);
+        return Promise.resolve(['config']);
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2022,10 +2023,10 @@ test('[commands.operations.createPreamble] success with template object', async 
     commands.operations.createPreamble(context);
 });
 
-test('[commands.operations.selectConfig] force-mode', async (t) => {
-    sinon.stub(prompt, 'configuration').callsFake(function(configs, callback) {
+test('[commands.operations.selectConfig] force-mode', async(t) => {
+    sinon.stub(Prompt, 'configuration').callsFake(() => {
         t.fail('should not prompt');
-        callback(new Error('failure'));
+        throw new Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2033,7 +2034,7 @@ test('[commands.operations.selectConfig] force-mode', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.notOk(context.configName, 'does not set context.configName');
-            prompt.configuration.restore();
+            Prompt.configuration.restore();
             t.end();
         }
     });
@@ -2041,8 +2042,8 @@ test('[commands.operations.selectConfig] force-mode', async (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] new config', async (t) => {
-    sinon.stub(prompt, 'configuration').callsFake((configs) => {
+test('[commands.operations.selectConfig] new config', async(t) => {
+    sinon.stub(Prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('New configuration');
     });
@@ -2052,7 +2053,7 @@ test('[commands.operations.selectConfig] new config', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.notOk(context.configName, 'does not set context.configName');
-            prompt.configuration.restore();
+            Prompt.configuration.restore();
             t.end();
         }
     });
@@ -2060,8 +2061,8 @@ test('[commands.operations.selectConfig] new config', async (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.selectConfig] saved config', async (t) => {
-    sinon.stub(prompt, 'configuration').callsFake((configs) => {
+test('[commands.operations.selectConfig] saved config', async(t) => {
+    sinon.stub(Prompt, 'configuration').callsFake((configs) => {
         t.deepEqual(configs, context.configNames, 'prompted with correct config names');
         return Promise.resolve('config');
     });
@@ -2071,7 +2072,7 @@ test('[commands.operations.selectConfig] saved config', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.equal(context.configName, 'config', 'does set context.configName');
-            prompt.configuration.restore();
+            Prompt.configuration.restore();
             t.end();
         }
     });
@@ -2079,7 +2080,7 @@ test('[commands.operations.selectConfig] saved config', async (t) => {
     commands.operations.selectConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, no default', async (t) => {
+test('[commands.operations.loadConfig] no saved config, no default', async(t) => {
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
@@ -2091,10 +2092,10 @@ test('[commands.operations.loadConfig] no saved config, no default', async (t) =
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] no saved config, has default', async (t) => {
-    sinon.stub(Lookup, 'defaultConfiguration').callsFake(function(s3url, callback) {
+test('[commands.operations.loadConfig] no saved config, has default', async(t) => {
+    sinon.stub(Lookup, 'defaultConfiguration').callsFake((s3url) => {
         t.equal(s3url, 's3://my-bucket/my-default.cfn.json', 'requested correct configuration');
-        callback(null, { default: 'configuration' });
+        return Promise.resolve({ default: 'configuration' });
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2110,9 +2111,9 @@ test('[commands.operations.loadConfig] no saved config, has default', async (t) 
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] bucket not found', async (t) => {
-    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new Lookup.BucketNotFoundError('failure'));
+test('[commands.operations.loadConfig] bucket not found', async(t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(() => {
+        throw new Lookup.BucketNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2128,9 +2129,9 @@ test('[commands.operations.loadConfig] bucket not found', async (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] config not found', async (t) => {
-    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new Lookup.ConfigurationNotFoundError('failure'));
+test('[commands.operations.loadConfig] config not found', async(t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(() => {
+        throw new Lookup.ConfigurationNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2146,9 +2147,9 @@ test('[commands.operations.loadConfig] config not found', async (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] invalid config', async (t) => {
-    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new Lookup.InvalidConfigurationError('failure'));
+test('[commands.operations.loadConfig] invalid config', async(t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(() => {
+        throw new Lookup.InvalidConfigurationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2164,9 +2165,9 @@ test('[commands.operations.loadConfig] invalid config', async (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] failed to load config', async (t) => {
-    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
-        callback(new Lookup.S3Error('failure'));
+test('[commands.operations.loadConfig] failed to load config', async(t) => {
+    sinon.stub(Lookup, 'configuration').callsFake(() => {
+        throw new Lookup.S3Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2182,12 +2183,12 @@ test('[commands.operations.loadConfig] failed to load config', async (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.loadConfig] success', async (t) => {
-    sinon.stub(Lookup, 'configuration').callsFake(function(name, bucket, config, callback) {
+test('[commands.operations.loadConfig] success', async(t) => {
+    sinon.stub(Lookup, 'configuration').callsFake((name, bucket, config) => {
         t.equal(name, context.baseName, 'expected stack name');
         t.equal(bucket, context.configBucket, 'expected config bucket');
         t.equal(config, context.configName, 'expected config name');
-        callback(null, { saved: 'configuration' });
+        return Promise.resolve({ saved: 'configuration' });
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2203,17 +2204,17 @@ test('[commands.operations.loadConfig] success', async (t) => {
     commands.operations.loadConfig(context);
 });
 
-test('[commands.operations.confirmCreate] force-mode', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake(function(message, callback) {
+test('[commands.operations.confirmCreate] force-mode', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake(() => {
         t.fail('should not prompt');
-        callback(new Error('failure'));
+        throw new Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2221,8 +2222,8 @@ test('[commands.operations.confirmCreate] force-mode', async (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] reject', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake(() => {
+test('[commands.operations.confirmCreate] reject', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
 
@@ -2230,7 +2231,7 @@ test('[commands.operations.confirmCreate] reject', async (t) => {
         configName: 'config',
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2238,8 +2239,8 @@ test('[commands.operations.confirmCreate] reject', async (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmCreate] accept', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+test('[commands.operations.confirmCreate] accept', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to create the stack?', 'expected message');
         return Promise.resolve(true);
     });
@@ -2248,7 +2249,7 @@ test('[commands.operations.confirmCreate] accept', async (t) => {
         configName: 'config',
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2256,7 +2257,7 @@ test('[commands.operations.confirmCreate] accept', async (t) => {
     commands.operations.confirmCreate(context);
 });
 
-test('[commands.operations.confirmDelete] force-mode', async (t) => {
+test('[commands.operations.confirmDelete] force-mode', async(t) => {
     const context = Object.assign({}, basicContext, {
         overrides: { force: true },
         next: function(err) {
@@ -2268,8 +2269,8 @@ test('[commands.operations.confirmDelete] force-mode', async (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] reject', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
+test('[commands.operations.confirmDelete] reject', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?');
         t.equal(defaultValue, false);
         return Promise.resolve(false);
@@ -2278,7 +2279,7 @@ test('[commands.operations.confirmDelete] reject', async (t) => {
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2286,8 +2287,8 @@ test('[commands.operations.confirmDelete] reject', async (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.confirmDelete] accept', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message, defaultValue) => {
+test('[commands.operations.confirmDelete] accept', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message, defaultValue) => {
         t.equal(message, 'Are you sure you want to delete my-stack-testing in region us-east-1?', 'expected message');
         t.equal(defaultValue, false);
         return Promise.resolve(true);
@@ -2296,7 +2297,7 @@ test('[commands.operations.confirmDelete] accept', async (t) => {
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2304,16 +2305,16 @@ test('[commands.operations.confirmDelete] accept', async (t) => {
     commands.operations.confirmDelete(context);
 });
 
-test('[commands.operations.deleteStack] failure', async (t) => {
-    sinon.stub(actions, 'delete').callsFake(function(name, region, callback) {
-        callback(new actions.CloudFormationError('failure'));
+test('[commands.operations.deleteStack] failure', async(t) => {
+    sinon.stub(Actions, 'delete').callsFake(() => {
+        throw new Actions.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
-            t.ok(err instanceof actions.CloudFormationError, 'expected error type');
+            t.ok(err instanceof Actions.CloudFormationError, 'expected error type');
             t.equal(err.message, 'Failed to delete stack: failure', 'expected error message');
-            actions.delete.restore();
+            Actions.delete.restore();
             t.end();
         }
     });
@@ -2321,17 +2322,17 @@ test('[commands.operations.deleteStack] failure', async (t) => {
     commands.operations.deleteStack(context);
 });
 
-test('[commands.operations.deleteStack] success', async (t) => {
-    sinon.stub(actions, 'delete').callsFake(function(name, region, callback) {
+test('[commands.operations.deleteStack] success', async(t) => {
+    sinon.stub(Actions, 'delete').callsFake((name, region) => {
         t.equal(name, context.stackName, 'deleted expected stack');
         t.equal(region, context.stackRegion, 'deleted in expected region');
-        callback();
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
-            actions.delete.restore();
+            Actions.delete.restore();
             t.end();
         }
     });
@@ -2339,15 +2340,15 @@ test('[commands.operations.deleteStack] success', async (t) => {
     commands.operations.deleteStack(context);
 });
 
-test('[commands.operations.monitorStack] failure', async (t) => {
-    sinon.stub(actions, 'monitor').callsFake(function(name, region, callback) {
-        callback(new actions.CloudFormationError('failure'));
+test('[commands.operations.monitorStack] failure', async(t) => {
+    sinon.stub(Actions, 'monitor').callsFake(() => {
+        throw new Actions.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         abort: function(err) {
             t.equal(err.message, `Monitoring your deploy failed, but the deploy in region ${context.stackRegion} will continue. Check on your stack's status in the CloudFormation console.`);
-            actions.monitor.restore();
+            Actions.monitor.restore();
             t.end();
         }
     });
@@ -2355,17 +2356,17 @@ test('[commands.operations.monitorStack] failure', async (t) => {
     commands.operations.monitorStack(context);
 });
 
-test('[commands.operations.monitorStack] success', async (t) => {
-    sinon.stub(actions, 'monitor').callsFake(function(name, region, callback) {
+test('[commands.operations.monitorStack] success', async(t) => {
+    sinon.stub(Actions, 'monitor').callsFake((name, region) => {
         t.equal(name, context.stackName, 'monitor expected stack');
         t.equal(region, context.stackRegion, 'monitor in expected region');
-        callback();
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
         next: function(err) {
             t.ifError(err, 'success');
-            actions.monitor.restore();
+            Actions.monitor.restore();
             t.end();
         }
     });
@@ -2373,9 +2374,9 @@ test('[commands.operations.monitorStack] success', async (t) => {
     commands.operations.monitorStack(context);
 });
 
-test('[commands.operations.getOldParameters] missing stack', async (t) => {
-    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new Lookup.StackNotFoundError('failure'));
+test('[commands.operations.getOldParameters] missing stack', async(t) => {
+    sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
+        throw new Lookup.StackNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2390,9 +2391,9 @@ test('[commands.operations.getOldParameters] missing stack', async (t) => {
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] failed to lookup stack', async (t) => {
-    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
-        callback(new Lookup.CloudFormationError('failure'));
+test('[commands.operations.getOldParameters] failed to lookup stack', async(t) => {
+    sinon.stub(Lookup, 'parameters').callsFake(() => {
+        throw new Lookup.CloudFormationError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2407,11 +2408,11 @@ test('[commands.operations.getOldParameters] failed to lookup stack', async (t) 
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.getOldParameters] success', async (t) => {
-    sinon.stub(Lookup, 'parameters').callsFake(function(name, region, callback) {
+test('[commands.operations.getOldParameters] success', async(t) => {
+    sinon.stub(Lookup, 'parameters').callsFake((name, region) => {
         t.equal(name, context.stackName, 'lookup expected stack');
         t.equal(region, context.stackRegion, 'lookup in expected region');
-        callback(null, { old: 'parameters' });
+        return Promise.resolve({ old: 'parameters' });
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2426,8 +2427,8 @@ test('[commands.operations.getOldParameters] success', async (t) => {
     commands.operations.getOldParameters(context);
 });
 
-test('[commands.operations.promptSaveConfig]', async (t) => {
-    sinon.stub(prompt, 'input').callsFake((message, def) => {
+test('[commands.operations.promptSaveConfig]', async(t) => {
+    sinon.stub(Prompt, 'input').callsFake((message, def) => {
         t.equal(message, 'Name for saved configuration:', 'expected prompt');
         t.equal(def, context.suffix, 'expected default value');
         return Promise.resolve('chuck');
@@ -2438,7 +2439,7 @@ test('[commands.operations.promptSaveConfig]', async (t) => {
         next: function(err) {
             t.ifError(err, 'success');
             t.equal(context.saveName, 'chuck', 'sets context.saveName');
-            prompt.input.restore();
+            Prompt.input.restore();
             t.end();
         }
     });
@@ -2446,8 +2447,8 @@ test('[commands.operations.promptSaveConfig]', async (t) => {
     commands.operations.promptSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] reject', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake(() => {
+test('[commands.operations.confirmSaveConfig] reject', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake(() => {
         return Promise.resolve(false);
     });
 
@@ -2455,7 +2456,7 @@ test('[commands.operations.confirmSaveConfig] reject', async (t) => {
         oldParameters: { old: 'parameters' },
         abort: function(err) {
             t.ifError(err, 'aborted');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2463,8 +2464,8 @@ test('[commands.operations.confirmSaveConfig] reject', async (t) => {
     commands.operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.confirmSaveConfig] accept', async (t) => {
-    sinon.stub(prompt, 'confirm').callsFake((message) => {
+test('[commands.operations.confirmSaveConfig] accept', async(t) => {
+    sinon.stub(Prompt, 'confirm').callsFake((message) => {
         t.equal(message, 'Ready to save this configuration as "hello"?', 'expected message');
         return Promise.resolve(true);
     });
@@ -2474,7 +2475,7 @@ test('[commands.operations.confirmSaveConfig] accept', async (t) => {
         oldParameters: { old: 'parameters' },
         next: function(err) {
             t.ifError(err, 'success');
-            prompt.confirm.restore();
+            Prompt.confirm.restore();
             t.end();
         }
     });
@@ -2482,18 +2483,18 @@ test('[commands.operations.confirmSaveConfig] accept', async (t) => {
     commands.operations.confirmSaveConfig(context);
 });
 
-test('[commands.operations.saveConfig] bucket not found', async (t) => {
-    sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
-        callback(new actions.BucketNotFoundError('failure'));
+test('[commands.operations.saveConfig] bucket not found', async(t) => {
+    sinon.stub(Actions, 'saveConfiguration').callsFake(() => {
+        throw new Actions.BucketNotFoundError('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         kms: true,
         abort: function(err) {
-            t.ok(err instanceof actions.BucketNotFoundError, 'expected error type');
+            t.ok(err instanceof Actions.BucketNotFoundError, 'expected error type');
             t.equal(err.message, 'Could not find template bucket: failure');
-            actions.saveConfiguration.restore();
+            Actions.saveConfiguration.restore();
             t.end();
         }
     });
@@ -2501,18 +2502,18 @@ test('[commands.operations.saveConfig] bucket not found', async (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] failure', async (t) => {
-    sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
-        callback(new actions.S3Error('failure'));
+test('[commands.operations.saveConfig] failure', async(t) => {
+    sinon.stub(Actions, 'saveConfiguration').callsFake(() => {
+        throw new Actions.S3Error('failure');
     });
 
     const context = Object.assign({}, basicContext, {
         oldParameters: { old: 'parameters' },
         kms: true,
         abort: function(err) {
-            t.ok(err instanceof actions.S3Error, 'expected error type');
+            t.ok(err instanceof Actions.S3Error, 'expected error type');
             t.equal(err.message, 'Failed to save template: failure');
-            actions.saveConfiguration.restore();
+            Actions.saveConfiguration.restore();
             t.end();
         }
     });
@@ -2520,15 +2521,15 @@ test('[commands.operations.saveConfig] failure', async (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.saveConfig] success', async (t) => {
-    sinon.stub(actions, 'saveConfiguration').callsFake(function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
+test('[commands.operations.saveConfig] success', async(t) => {
+    sinon.stub(Actions, 'saveConfiguration').callsFake((baseName, stackName, stackRegion, bucket, parameters, kms) => {
         t.equal(baseName, context.baseName, 'save under correct stack name');
         t.equal(stackName, context.stackName, 'save under correct stack name');
         t.equal(stackRegion, context.stackRegion, 'save under correct stack region');
         t.equal(bucket, context.configBucket, 'save in correct bucket');
         t.deepEqual(parameters, { new: 'parameters' }, 'save correct config');
         t.equal(kms, 'alias/cloudformation', 'use appropriate kms setting');
-        callback();
+        return Promise.resolve();
     });
 
     const context = Object.assign({}, basicContext, {
@@ -2536,7 +2537,7 @@ test('[commands.operations.saveConfig] success', async (t) => {
         overrides: { kms: true },
         next: function(err) {
             t.ifError(err, 'success');
-            actions.saveConfiguration.restore();
+            Actions.saveConfiguration.restore();
             t.end();
         }
     });
@@ -2544,7 +2545,7 @@ test('[commands.operations.saveConfig] success', async (t) => {
     commands.operations.saveConfig(context);
 });
 
-test('[commands.operations.mergeMetadata]', async (t) => {
+test('[commands.operations.mergeMetadata]', async(t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template' },
@@ -2563,7 +2564,7 @@ test('[commands.operations.mergeMetadata]', async (t) => {
     commands.operations.mergeMetadata(context);
 });
 
-test('[commands.operations.mergeMetadata] error', async (t) => {
+test('[commands.operations.mergeMetadata] error', async(t) => {
     const context = Object.assign({}, basicContext, {
         stackRegion: 'us-west-2',
         newTemplate: { new: 'template', Metadata: { LastDeploy: 'jane' } },

--- a/test/fixtures/huge-template.js
+++ b/test/fixtures/huge-template.js
@@ -1,11 +1,11 @@
 module.exports = {
-  Resources: new Array(5000).fill(0).reduce((resources, _, i) => {
-    resources['Thing' + i] = {
-      Type: 'AWS::SNS::Topic',
-      Properties: {
-        TopicName: 'Thing' + i
-      }
-    };
-    return resources;
-  }, {})
+    Resources: new Array(5000).fill(0).reduce((resources, _, i) => {
+        resources['Thing' + i] = {
+            Type: 'AWS::SNS::Topic',
+            Properties: {
+                TopicName: 'Thing' + i
+            }
+        };
+        return resources;
+    }, {})
 };

--- a/test/fixtures/simplest-template.json
+++ b/test/fixtures/simplest-template.json
@@ -1,30 +1,30 @@
 {
-  "Parameters": {
-    "Email": {
-      "Type": "String",
-      "Description": "An email address"
-    }
-  },
-  "Resources": {
-    "Topic": {
-      "Type": "AWS::SNS::Topic",
-      "Properties": {
-        "Subscription": [
-          {
-            "Protocol": "email",
-            "Endpoint": {
-              "Ref": "Email"
+    "Parameters": {
+        "Email": {
+            "Type": "String",
+            "Description": "An email address"
+        }
+    },
+    "Resources": {
+        "Topic": {
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "Subscription": [
+                    {
+                        "Protocol": "email",
+                        "Endpoint": {
+                            "Ref": "Email"
+                        }
+                    }
+                ]
             }
-          }
-        ]
-      }
+        }
+    },
+    "Outputs": {
+        "Blah": {
+            "Value": {
+                "Ref": "Email"
+            }
+        }
     }
-  },
-  "Outputs": {
-    "Blah": {
-      "Value": {
-        "Ref": "Email"
-      }
-    }
-  }
 }

--- a/test/fixtures/template-async.js
+++ b/test/fixtures/template-async.js
@@ -1,3 +1,3 @@
 module.exports = function(options, callback) {
-  setTimeout(callback, 10, null, options);
+    setTimeout(callback, 10, null, options);
 };

--- a/test/fixtures/template-sync.js
+++ b/test/fixtures/template-sync.js
@@ -1,44 +1,44 @@
 module.exports = {
-  Parameters: {
-    Name: {
-      Type: 'String',
-      Description: 'Someone\'s first name',
-      AllowedPattern: '[A-Z][a-z]+',
-      ConstraintDescription: 'must be capitalized and only contain letters'
+    Parameters: {
+        Name: {
+            Type: 'String',
+            Description: 'Someone\'s first name',
+            AllowedPattern: '[A-Z][a-z]+',
+            ConstraintDescription: 'must be capitalized and only contain letters'
+        },
+        Age: {
+            Type: 'Number',
+            MinValue: 0,
+            MaxValue: 150
+        },
+        Handedness: {
+            Type: 'String',
+            Description: 'Their dominant hand',
+            Default: 'right',
+            AllowedValues: ['left', 'right']
+        },
+        Pets: {
+            Type: 'CommaDelimitedList',
+            Description: 'The names of their pets'
+        },
+        LuckyNumbers: {
+            Type: 'List<Number>',
+            Description: 'Their lucky numbers'
+        },
+        SecretPassword: {
+            Type: 'String',
+            Description: '[secure] Their secret password',
+            MinLength: 8,
+            MaxLength: 24,
+            NoEcho: true
+        }
     },
-    Age: {
-      Type: 'Number',
-      MinValue: 0,
-      MaxValue: 150
+    Resources: {
+        Topic: {
+            Type: 'AWS::SNS::Topic'
+        }
     },
-    Handedness: {
-      Type: 'String',
-      Description: 'Their dominant hand',
-      Default: 'right',
-      AllowedValues: ['left', 'right']
-    },
-    Pets: {
-      Type: 'CommaDelimitedList',
-      Description: 'The names of their pets'
-    },
-    LuckyNumbers: {
-      Type: 'List<Number>',
-      Description: 'Their lucky numbers'
-    },
-    SecretPassword: {
-      Type: 'String',
-      Description: '[secure] Their secret password',
-      MinLength: 8,
-      MaxLength: 24,
-      NoEcho: true
+    Outputs: {
+        Blah: { Value: 'blah', Description: 'nothing' }
     }
-  },
-  Resources: {
-    Topic: {
-      Type: 'AWS::SNS::Topic'
-    }
-  },
-  Outputs: {
-    Blah: { Value: 'blah', Description: 'nothing' }
-  }
 };

--- a/test/fixtures/template.json
+++ b/test/fixtures/template.json
@@ -1,50 +1,50 @@
 {
-  "Parameters": {
-    "Name": {
-      "Type": "String",
-      "Description": "Someone's first name",
-      "AllowedPattern": "[A-Z][a-z]+",
-      "ConstraintDescription": "must be capitalized and only contain letters"
+    "Parameters": {
+        "Name": {
+            "Type": "String",
+            "Description": "Someone's first name",
+            "AllowedPattern": "[A-Z][a-z]+",
+            "ConstraintDescription": "must be capitalized and only contain letters"
+        },
+        "Age": {
+            "Type": "Number",
+            "MinValue": 0,
+            "MaxValue": 150
+        },
+        "Handedness": {
+            "Type": "String",
+            "Description": "Their dominant hand",
+            "Default": "right",
+            "AllowedValues": [
+                "left",
+                "right"
+            ]
+        },
+        "Pets": {
+            "Type": "CommaDelimitedList",
+            "Description": "The names of their pets"
+        },
+        "LuckyNumbers": {
+            "Type": "List<Number>",
+            "Description": "Their lucky numbers"
+        },
+        "SecretPassword": {
+            "Type": "String",
+            "Description": "[secure] Their secret password",
+            "MinLength": 8,
+            "MaxLength": 24,
+            "NoEcho": true
+        }
     },
-    "Age": {
-      "Type": "Number",
-      "MinValue": 0,
-      "MaxValue": 150
+    "Resources": {
+        "Topic": {
+            "Type": "AWS::SNS::Topic"
+        }
     },
-    "Handedness": {
-      "Type": "String",
-      "Description": "Their dominant hand",
-      "Default": "right",
-      "AllowedValues": [
-        "left",
-        "right"
-      ]
-    },
-    "Pets": {
-      "Type": "CommaDelimitedList",
-      "Description": "The names of their pets"
-    },
-    "LuckyNumbers": {
-      "Type": "List<Number>",
-      "Description": "Their lucky numbers"
-    },
-    "SecretPassword": {
-      "Type": "String",
-      "Description": "[secure] Their secret password",
-      "MinLength": 8,
-      "MaxLength": 24,
-      "NoEcho": true
+    "Outputs": {
+        "Blah": {
+            "Value": "blah",
+            "Description": "nothing"
+        }
     }
-  },
-  "Resources": {
-    "Topic": {
-      "Type": "AWS::SNS::Topic"
-    }
-  },
-  "Outputs": {
-    "Blah": {
-      "Value": "blah",
-      "Description": "nothing"
-    }
-  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ test('[preauth]', (t) => {
         secretAccessKey: 'b'
     });
 
-    var cfn = new AWS.CloudFormation({ region: 'us-east-1' });
+    const cfn = new AWS.CloudFormation({ region: 'us-east-1' });
     t.deepEqual(cfn.config.credentials, {
         accessKeyId: 'a',
         secretAccessKey: 'b'

--- a/test/lookups.test.js
+++ b/test/lookups.test.js
@@ -1,49 +1,61 @@
 const test = require('tape');
-const lookup = require('../lib/lookup');
+const Lookup = require('../lib/lookup');
 const AWS = require('@mapbox/mock-aws-sdk-js');
 
 const template = require('./fixtures/template.json');
 
-test('[lookup.info] describeStacks error', (t) => {
+test('[lookup.info] describeStacks error', async (t) => {
     AWS.stub('CloudFormation', 'describeStacks').yields(new Error('cloudformation failed'));
 
-    lookup.info('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.info('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.info] stack does not exist', (t) => {
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        var err = new Error('Stack with id my-stack does not exist');
+test('[lookup.info] stack does not exist', async (t) => {
+    AWS.stub('CloudFormation', 'describeStacks', (params) => {
+        const err = new Error('Stack with id my-stack does not exist');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    lookup.info('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.StackNotFoundError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.info('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.info] stack info not returned', (t) => {
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [] });
+test('[lookup.info] stack info not returned', async (t) => {
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [] })
     });
 
-    lookup.info('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.StackNotFoundError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.info('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.info] success', (t) => {
-    var date = new Date();
+test('[lookup.info] success', async (t) => {
+    const date = new Date();
 
-    var stackInfo = {
+    const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
@@ -62,22 +74,18 @@ test('[lookup.info] success', (t) => {
         NotificationARNs: ['some-arn'],
         TimeoutInMinutes: 10,
         Capabilities: 'CAPABILITY_IAM',
-        Outputs: [
-            {
-                OutputKey: 'Blah',
-                OutputValue: 'blah',
-                Description: 'nothing'
-            }
-        ],
-        Tags: [
-            {
-                Key: 'Category',
-                Value: 'Peeps'
-            }
-        ]
+        Outputs: [{
+            OutputKey: 'Blah',
+            OutputValue: 'blah',
+            Description: 'nothing'
+        }],
+        Tags: [{
+            Key: 'Category',
+            Value: 'Peeps'
+        }]
     };
 
-    var expected = {
+    const expected = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
@@ -101,40 +109,53 @@ test('[lookup.info] success', (t) => {
         Tags: { Category: 'Peeps' }
     };
 
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [stackInfo] });
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [ stackInfo] })
     });
 
-    lookup.info('my-stack', 'us-east-1', function(err, info) {
-        t.ifError(err, 'success');
+    try {
+        const info = await Lookup.info('my-stack', 'us-east-1');
         t.deepEqual(info, expected, 'expected info returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test.test('[lookup.info] with resources', (t) => {
-    AWS.stub('CloudFormation', 'describeStacks').yields(null, { Stacks: [{}] });
+test.test('[lookup.info] with resources', async (t) => {
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [{}] })
+    });
+
+    const stack = [
+        { StackResourceSummaries: [{ resource1: 'ohai' }], NextToken: '1' },
+        { StackResourceSummaries: [{ resource2: 'ohai' }], NextToken: null }
+    ].reverse();
+
     AWS.stub('CloudFormation', 'listStackResources').returns({
-        eachPage: (callback) => {
-            callback(null, { StackResourceSummaries: [{ resource1: 'ohai' }] }, () => {
-                callback(null, { StackResourceSummaries: [{ resource2: 'ohai' }] }, () => {
-                    callback();
-                });
-            });
-        }
+        promise: () => Promise.resolve(stack.pop())
     });
 
-    lookup.info('my-stack', 'us-east-1', true, function(err, info) {
-        t.ifError(err, 'success');
-        t.deepEqual(info.StackResources, [{ resource1: 'ohai' }, { resource2: 'ohai' }], 'added stack resources');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        const info = await Lookup.info('my-stack', 'us-east-1', true);
+
+        t.deepEqual(info.StackResources, [
+            { resource1: 'ohai' },
+            { resource2: 'ohai' }
+        ], 'added stack resources');
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test.test('[lookup.info] resource lookup failure', (t) => {
-    AWS.stub('CloudFormation', 'describeStacks').yields(null, { Stacks: [{}] });
+test.test('[lookup.info] resource lookup failure', async (t) => {
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [{}] })
+    });
 
     AWS.stub('CloudFormation', 'listStackResources').returns({
         eachPage: (callback) => {
@@ -144,36 +165,44 @@ test.test('[lookup.info] resource lookup failure', (t) => {
         }
     });
 
-    lookup.info('my-stack', 'us-east-1', true, function(err) {
-        t.ok(err instanceof lookup.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.info('my-stack', 'us-east-1', true);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.parameters] lookup.info error', (t) => {
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [] });
+test('[lookup.parameters] lookup.info error', async (t) => {
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [] })
     });
 
-    lookup.parameters('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.StackNotFoundError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.parameters('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.info] secure', (t) => {
-    var date = new Date();
+test('[lookup.info] secure', async (t) => {
+    const date = new Date();
 
-    var stackInfo = {
+    const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
         Parameters: [
             { ParameterKey: 'PlainText', ParameterValue: 'Hello world!' },
-            { ParameterKey: 'SecureVarA', ParameterValue: 'secure:' + (new Buffer('EncryptedValue1')).toString('base64') },
-            { ParameterKey: 'SecureVarB', ParameterValue: 'secure:' + (new Buffer('EncryptedValue2')).toString('base64') }
+            { ParameterKey: 'SecureVarA', ParameterValue: 'secure:' + (new Buffer.from('EncryptedValue1')).toString('base64') },
+            { ParameterKey: 'SecureVarB', ParameterValue: 'secure:' + (new Buffer.from('EncryptedValue2')).toString('base64') }
         ],
         CreationTime: date,
         LastUpdatedTime: date,
@@ -186,7 +215,7 @@ test('[lookup.info] secure', (t) => {
         Tags: []
     };
 
-    var expected = {
+    const expected = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
@@ -207,37 +236,42 @@ test('[lookup.info] secure', (t) => {
         Tags: {}
     };
 
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [stackInfo] });
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [stackInfo] })
     });
 
-    AWS.stub('KMS', 'decrypt', function(params, callback) {
-        var encrypted = new Buffer(params.CiphertextBlob, 'base64').toString('utf8');
-        if (encrypted === 'EncryptedValue1')
-            return callback(null, { Plaintext: (new Buffer('DecryptedValue1')).toString('base64') });
-        if (encrypted === 'EncryptedValue2')
-            return callback(null, { Plaintext: (new Buffer('DecryptedValue2')).toString('base64') });
+    AWS.stub('KMS', 'decrypt', function(params) {
+        const encrypted = new Buffer.from(params.CiphertextBlob, 'base64').toString('utf8');
+
+        if (encrypted === 'EncryptedValue1') {
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }))
+        } else if (encrypted === 'EncryptedValue2') {
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }))
+        }
         t.fail('Unrecognized encrypted value ' + encrypted);
     });
 
-    lookup.info('my-stack', 'us-east-1', false, true, function(err, info) {
-        t.ifError(err, 'success');
+    try {
+        const info = await Lookup.info('my-stack', 'us-east-1', false, true);
         t.deepEqual(info, expected, 'expected info returned');
-        AWS.CloudFormation.restore();
-        AWS.KMS.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    AWS.KMS.restore();
+    t.end();
 });
 
-test('[lookup.info] secure error', (t) => {
-    var stackInfo = {
+test('[lookup.info] secure error', async (t) => {
+    const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
         Parameters: [
             { ParameterKey: 'PlainText', ParameterValue: 'Hello world!' },
-            { ParameterKey: 'SecureVarA', ParameterValue: 'secure:' + (new Buffer('EncryptedValue1')).toString('base64') },
-            { ParameterKey: 'SecureVarB', ParameterValue: 'secure:' + (new Buffer('EncryptedValue2')).toString('base64') }
+            { ParameterKey: 'SecureVarA', ParameterValue: 'secure:' + (new Buffer.from('EncryptedValue1')).toString('base64') },
+            { ParameterKey: 'SecureVarB', ParameterValue: 'secure:' + (new Buffer.from('EncryptedValue2')).toString('base64') }
         ],
         CreationTime: new Date(),
         LastUpdatedTime: new Date(),
@@ -250,24 +284,26 @@ test('[lookup.info] secure error', (t) => {
         Tags: []
     };
 
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [stackInfo] });
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [stackInfo] })
     });
 
-    AWS.stub('KMS', 'decrypt', function(params, callback) {
-        callback(new Error('KMS decryption error'));
-    });
+    AWS.stub('KMS', 'decrypt').yields(new Error('KMS decryption error'));
 
-    lookup.info('my-stack', 'us-east-1', false, true, function(err) {
-        t.ok(err instanceof lookup.DecryptParametersError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        AWS.KMS.restore();
-        t.end();
-    });
+    try {
+        await Lookup.info('my-stack', 'us-east-1', false, true);
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.DecryptParametersError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    AWS.KMS.restore();
+    t.end();
 });
 
-test('[lookup.parameters] success', (t) => {
-    var stackInfo = {
+test('[lookup.parameters] success', async (t) => {
+    const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
         Description: 'test-stack',
@@ -286,22 +322,18 @@ test('[lookup.parameters] success', (t) => {
         NotificationARNs: ['some-arn'],
         TimeoutInMinutes: 10,
         Capabilities: 'CAPABILITY_IAM',
-        Outputs: [
-            {
-                OutputKey: 'Blah',
-                OutputValue: 'blah',
-                Description: 'nothing'
-            }
-        ],
-        Tags: [
-            {
-                Key: 'Category',
-                Value: 'Peeps'
-            }
-        ]
+        Outputs: [{
+            OutputKey: 'Blah',
+            OutputValue: 'blah',
+            Description: 'nothing'
+        }],
+        Tags: [{
+            Key: 'Category',
+            Value: 'Peeps'
+        }]
     };
 
-    var expected = {
+    const expected = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -310,260 +342,309 @@ test('[lookup.parameters] success', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('CloudFormation', 'describeStacks', function(params, callback) {
-        callback(null, { Stacks: [stackInfo] });
+    AWS.stub('CloudFormation', 'describeStacks').returns({
+        promise: () => Promise.resolve({ Stacks: [stackInfo] })
     });
 
-    lookup.parameters('my-stack', 'us-east-1', function(err, info) {
-        t.ifError(err, 'success');
+    try {
+        const info = await Lookup.parameters('my-stack', 'us-east-1');
         t.deepEqual(info, expected, 'expected parameters returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.template] getTemplate error', (t) => {
-    AWS.stub('CloudFormation', 'getTemplate', function(params, callback) {
-        callback(new Error('cloudformation failed'));
-    });
+test('[lookup.template] getTemplate error', async (t) => {
+    AWS.stub('CloudFormation', 'getTemplate').yields(new Error('cloudformation failed'));
 
-    lookup.template('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.CloudFormationError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.template('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.CloudFormationError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.template] stack does not exist', (t) => {
-    AWS.stub('CloudFormation', 'getTemplate', function(params, callback) {
-        var err = new Error('Stack with id my-stack does not exist');
+test('[lookup.template] stack does not exist', async (t) => {
+    AWS.stub('CloudFormation', 'getTemplate', (params) => {
+        const err = new Error('Stack with id my-stack does not exist');
         err.code = 'ValidationError';
-        callback(err);
+        throw err;
     });
 
-    lookup.template('my-stack', 'us-east-1', function(err) {
-        t.ok(err instanceof lookup.StackNotFoundError, 'expected error returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    try {
+        await Lookup.template('my-stack', 'us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.StackNotFoundError, 'expected error returned');
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.template] success', (t) => {
-    AWS.stub('CloudFormation', 'getTemplate', function(params, callback) {
+test('[lookup.template] success', async (t) => {
+    AWS.stub('CloudFormation', 'getTemplate', function (params) {
         t.deepEqual(params, {
             StackName: 'my-stack',
             TemplateStage: 'Original'
         }, 'getTemplate call sets the TemplateStage');
 
-        callback(null, {
+        return this.request.promise.returns(Promise.resolve({
             RequestMetadata: { RequestId: 'db317457-46f2-11e6-8ee0-fbc06d2d1322' },
             TemplateBody: JSON.stringify(template)
-        });
+        }));
     });
 
-    lookup.template('my-stack', 'us-east-1', function(err, body) {
-        t.ifError(err, 'success');
+    try {
+        const body = await Lookup.template('my-stack', 'us-east-1');
         t.deepEqual(body, template, 'expected template body returned');
-        AWS.CloudFormation.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.CloudFormation.restore();
+    t.end();
 });
 
-test('[lookup.configurations] bucket location error', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(new Error('failure'));
-    });
+test('[lookup.configurations] bucket location error', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
-    lookup.configurations('my-stack', 'my-bucket', function(err) {
-        t.ok(err instanceof lookup.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configurations('my-stack', 'my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configurations] bucket does not exist', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configurations] bucket does not exist', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', function(params, callback) {
-        var err = new Error('The specified bucket does not exist');
+    AWS.stub('S3', 'listObjects', (params) => {
+        const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    lookup.configurations('my-stack', 'my-bucket', function(err) {
-        t.ok(err instanceof lookup.BucketNotFoundError, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configurations('my-stack', 'my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configurations] S3 error', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configurations] S3 error', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', function(params, callback) {
+    AWS.stub('S3', 'listObjects', (params) => {
         t.equal(params.Prefix, 'my-stack/', 'listObjects called with proper prefix');
-        var err = new Error('something unexpected');
-        callback(err);
+        throw new Error('something unexpected');
     });
 
-    lookup.configurations('my-stack', 'my-bucket', function(err) {
-        t.ok(err instanceof lookup.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configurations('my-stack', 'my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configurations] no saved configs found', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configurations] no saved configs found', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', function(params, callback) {
-        callback(null, { Contents: [] });
+    AWS.stub('S3', 'listObjects').returns({
+        promise: () => Promise.resolve({ Contents: [] })
     });
 
-    lookup.configurations('my-stack', 'my-bucket', function(err, configs) {
-        t.ifError(err, 'success');
+    try {
+        const configs = await Lookup.configurations('my-stack', 'my-bucket');
         t.deepEqual(configs, [], 'expected empty array of configs');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configurations] found multiple saved configs', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configurations] found multiple saved configs', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', function(params, callback) {
-        callback(null, {
+    AWS.stub('S3', 'listObjects').returns({
+        promise: () => Promise.resolve({
             Contents: [
                 { Key: 'my-stack/staging.cfn.json', Size: 10 },
                 { Key: 'my-stack/production.cfn.json', Size: 10 },
                 { Key: 'my-stack/something-else', Size: 10 },
                 { Key: 'my-stack/folder', Size: 0 }
             ]
-        });
+        })
     });
 
-    lookup.configurations('my-stack', 'my-bucket', function(err, configs) {
-        t.ifError(err, 'success');
+    try {
+        const configs = await Lookup.configurations('my-stack', 'my-bucket');
         t.deepEqual(configs, [
             'staging',
             'production'
         ], 'expected array of configs');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configurations] region specified', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configurations] region specified', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', function(params, callback) {
-        callback(null, { Contents: [] });
+    AWS.stub('S3', 'listObjects').returns({
+        promise: () => Promise.resolve({ Contents: [] })
     });
 
-    lookup.configurations('my-stack', 'my-bucket', 'cn-north-1', function() {
+    try {
+        await Lookup.configurations('my-stack', 'my-bucket', 'cn-north-1');
+
         t.ok(AWS.S3.calledWith({
             signatureVersion: 'v4',
             region: 'cn-north-1'
         }), 'created S3 client in requested region');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] bucket location error', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(new Error('failure'));
-    });
+test('[lookup.configuration] bucket location error', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
-        t.ok(err instanceof lookup.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] bucket does not exist', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configuration] bucket does not exist', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
-        var err = new Error('The specified bucket does not exist');
+    AWS.stub('S3', 'getObject', (params) => {
+        const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
-        t.ok(err instanceof lookup.BucketNotFoundError, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] S3 error', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configuration] S3 error', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
+    AWS.stub('S3', 'getObject', (params) => {
         t.equal(params.Key, 'my-stack/my-stack-staging-us-east-1.cfn.json', 'getObject called with proper key');
-        var err = new Error('something unexpected');
-        callback(err);
+        throw new Error('something unexpected');
     });
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
-        t.ok(err instanceof lookup.S3Error, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.S3Error, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] requested configuration does not exist', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configuration] requested configuration does not exist', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
-        var err = new Error('The specified key does not exist.');
+    AWS.stub('S3', 'getObject', (params) => {
+        const err = new Error('The specified key does not exist.');
         err.code = 'NoSuchKey';
-        callback(err);
+        throw err;
     });
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
-        t.ok(err instanceof lookup.ConfigurationNotFoundError, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.ConfigurationNotFoundError, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] cannot parse object data', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.configuration] cannot parse object data', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
-        callback(null, { Body: new Buffer('invalid') });
+    AWS.stub('S3', 'getObject').returns({
+        promise: () => Promise.resolve({ Body: new Buffer.from('invalid') })
     });
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
-        t.ok(err instanceof lookup.InvalidConfigurationError, 'expected error returned');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.InvalidConfigurationError, 'expected error returned');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.configuration] success', (t) => {
-    var info = {
+test('[lookup.configuration] success', async (t) => {
+    const info = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -572,78 +653,88 @@ test('[lookup.configuration] success', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
+    AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'my-stack/my-stack-staging-us-east-1.cfn.json'
         }, 'requested expected configuration');
 
-        callback(null, { Body: new Buffer(JSON.stringify(info)) });
+        return this.request.promise.returns(Promise.resolve({ Body: new Buffer.from(JSON.stringify(info)) }));
     });
 
-    lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err, configuration) {
-        t.ifError(err, 'success');
+    try {
+        const configuration = await Lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1');
         t.deepEqual(configuration, info, 'returned expected stack info');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.defaultConfiguration] bucket location error', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(new Error('failure'));
-    });
+test('[lookup.defaultConfiguration] bucket location error', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
-    lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json', function(err, info) {
-        t.ifError(err, 'ignored error');
+    try {
+        const info = await Lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json');
         t.deepEqual(info, {}, 'provided blank info');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.defaultConfiguration] requested configuration does not exist', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.defaultConfiguration] requested configuration does not exist', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
-        var err = new Error('The specified key does not exist.');
+    AWS.stub('S3', 'getObject', (params) =>  {
+        const err = new Error('The specified key does not exist.');
         err.code = 'NoSuchKey';
-        callback(err);
+        throw err;
     });
 
-    lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json', function(err, info) {
-        t.ifError(err, 'ignored error');
+    try {
+        const info = await Lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json');
         t.deepEqual(info, {}, 'provided blank info');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err)
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.defaultConfiguration] cannot parse object data', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+test('[lookup.defaultConfiguration] cannot parse object data', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
-        callback(null, { Body: new Buffer('invalid') });
+    AWS.stub('S3', 'getObject').returns({
+        promise: () => Promise.resolve({ Body: new Buffer.from('invalid') })
     });
 
-    lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json', function(err, info) {
-        t.ifError(err, 'ignored error');
+    try {
+        const info = await Lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json');
         t.deepEqual(info, {}, 'provided blank info');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.defaultConfiguration] success', (t) => {
-    var info = {
+test('[lookup.defaultConfiguration] success', async (t) => {
+    const info = {
         Name: 'Chuck',
         Age: 18,
         Handedness: 'left',
@@ -652,122 +743,146 @@ test('[lookup.defaultConfiguration] success', (t) => {
         SecretPassword: 'secret'
     };
 
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        callback(null, 'us-east-1');
+    AWS.stub('S3', 'getBucketLocation').returns({
+        promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', function(params, callback) {
+    AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, {
             Bucket: 'my-bucket',
             Key: 'my-config.cfn.json'
         }, 'requested expected default configuration');
 
-        callback(null, { Body: new Buffer(JSON.stringify(info)) });
+        return this.request.promise.returns(Promise.resolve({ Body: new Buffer.from(JSON.stringify(info)) }));
     });
 
-    lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json', function(err, configuration) {
-        t.ifError(err, 'success');
+    try {
+        const configuration = await Lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json');
         t.deepEqual(configuration, info, 'returned expected stack info');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.bucketRegion] no bucket', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        var err = new Error('failure');
+test('[lookup.bucketRegion] no bucket', async (t) => {
+    AWS.stub('S3', 'getBucketLocation', (params) => {
+        const err = new Error('failure');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    lookup.bucketRegion('my-bucket', function(err) {
-        t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.bucketRegion('my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error type');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.bucketRegion] failure', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        var err = new Error('failure');
-        callback(err);
-    });
+test('[lookup.bucketRegion] failure', async (t) => {
+    AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
-    lookup.bucketRegion('my-bucket', function(err) {
-        t.ok(err instanceof lookup.S3Error, 'expected error type');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.bucketRegion('my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.S3Error, 'expected error type');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.bucketRegion] no bucket', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        var err = new Error('failure');
+test('[lookup.bucketRegion] no bucket', async (t) => {
+    AWS.stub('S3', 'getBucketLocation', (params) => {
+        const err = new Error('failure');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    lookup.bucketRegion('my-bucket', function(err) {
-        t.ok(err instanceof lookup.BucketNotFoundError, 'expected error type');
-        AWS.S3.restore();
-        t.end();
-    });
+    try {
+        await Lookup.bucketRegion('my-bucket');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.BucketNotFoundError, 'expected error type');
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.bucketRegion] region specified', (t) => {
-    AWS.stub('S3', 'getBucketLocation', function(params, callback) {
-        var err = new Error('failure');
+test('[lookup.bucketRegion] region specified', async (t) => {
+    AWS.stub('S3', 'getBucketLocation', (params) => {
+        const err = new Error('failure');
         err.code = 'NoSuchBucket';
-        callback(err);
+        throw err;
     });
 
-    lookup.bucketRegion('my-bucket', 'cn-north-1', function() {
+    try {
+        await Lookup.bucketRegion('my-bucket', 'cn-north-1');
+
         t.ok(AWS.S3.calledWith({
             signatureVersion: 'v4',
             region: 'cn-north-1'
         }), 'used region in S3 client configuration');
-        AWS.S3.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error();
+    }
+
+    AWS.S3.restore();
+    t.end();
 });
 
-test('[lookup.decryptParameters] failure', (t) => {
-    AWS.stub('KMS', 'decrypt', function(params, callback) {
-        var err = new Error('failure');
-        callback(err);
-    });
+test('[lookup.decryptParameters] failure', async (t) => {
+    AWS.stub('KMS', 'decrypt',).yields(new Error('failure'));
 
-    lookup.decryptParameters({
-        ValueA: 'secure:0123456789'
-    }, 'us-west-1', function(err) {
-        t.ok(err instanceof lookup.DecryptParametersError, 'expected error type');
-        AWS.KMS.restore();
-        t.end();
-    });
+    try {
+        await Lookup.decryptParameters({
+            ValueA: 'secure:0123456789'
+        }, 'us-west-1');
+        t.fail();
+    } catch (err) {
+        t.ok(err instanceof Lookup.DecryptParametersError, 'expected error type');
+    }
+
+    AWS.KMS.restore();
+    t.end();
 });
 
-test('[lookup.decryptParameters] success', (t) => {
-    AWS.stub('KMS', 'decrypt', function(params, callback) {
-        var encrypted = new Buffer(params.CiphertextBlob, 'base64').toString('utf8');
-        if (encrypted === 'EncryptedValue1')
-            return callback(null, { Plaintext: (new Buffer('DecryptedValue1')).toString('base64') });
-        if (encrypted === 'EncryptedValue2')
-            return callback(null, { Plaintext: (new Buffer('DecryptedValue2')).toString('base64') });
+test('[lookup.decryptParameters] success', async (t) => {
+    AWS.stub('KMS', 'decrypt', function(params) {
+        const encrypted = new Buffer.from(params.CiphertextBlob, 'base64').toString('utf8');
+        if (encrypted === 'EncryptedValue1') {
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }))
+        } else if (encrypted === 'EncryptedValue2') {
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }))
+        }
+
         t.fail('Unrecognized encrypted value ' + encrypted);
     });
 
-    lookup.decryptParameters({
-        PlainText: 'Hello world!',
-        SecureVarA: 'secure:' + (new Buffer('EncryptedValue1')).toString('base64'),
-        SecureVarB: 'secure:' + (new Buffer('EncryptedValue2')).toString('base64')
-    }, 'us-west-1', function(err, decryptedParams) {
-        t.ifError(err, 'success');
+    try {
+        const decryptedParams = await Lookup.decryptParameters({
+            PlainText: 'Hello world!',
+            SecureVarA: 'secure:' + (new Buffer.from('EncryptedValue1')).toString('base64'),
+            SecureVarB: 'secure:' + (new Buffer.from('EncryptedValue2')).toString('base64')
+        }, 'us-west-1');
+
         t.deepEqual(decryptedParams, {
             PlainText: 'Hello world!',
             SecureVarA: 'DecryptedValue1',
             SecureVarB: 'DecryptedValue2'
         }, 'decryptes secure parameters');
-        AWS.KMS.restore();
-        t.end();
-    });
+    } catch (err) {
+        t.error(err);
+    }
+
+    AWS.KMS.restore();
+    t.end();
 });

--- a/test/lookups.test.js
+++ b/test/lookups.test.js
@@ -4,7 +4,7 @@ const AWS = require('@mapbox/mock-aws-sdk-js');
 
 const template = require('./fixtures/template.json');
 
-test('[lookup.info] describeStacks error', async (t) => {
+test('[lookup.info] describeStacks error', async(t) => {
     AWS.stub('CloudFormation', 'describeStacks').yields(new Error('cloudformation failed'));
 
     try {
@@ -18,8 +18,8 @@ test('[lookup.info] describeStacks error', async (t) => {
     t.end();
 });
 
-test('[lookup.info] stack does not exist', async (t) => {
-    AWS.stub('CloudFormation', 'describeStacks', (params) => {
+test('[lookup.info] stack does not exist', async(t) => {
+    AWS.stub('CloudFormation', 'describeStacks', () => {
         const err = new Error('Stack with id my-stack does not exist');
         err.code = 'ValidationError';
         throw err;
@@ -36,7 +36,7 @@ test('[lookup.info] stack does not exist', async (t) => {
     t.end();
 });
 
-test('[lookup.info] stack info not returned', async (t) => {
+test('[lookup.info] stack info not returned', async(t) => {
     AWS.stub('CloudFormation', 'describeStacks').returns({
         promise: () => Promise.resolve({ Stacks: [] })
     });
@@ -52,7 +52,7 @@ test('[lookup.info] stack info not returned', async (t) => {
     t.end();
 });
 
-test('[lookup.info] success', async (t) => {
+test('[lookup.info] success', async(t) => {
     const date = new Date();
 
     const stackInfo = {
@@ -110,7 +110,7 @@ test('[lookup.info] success', async (t) => {
     };
 
     AWS.stub('CloudFormation', 'describeStacks').returns({
-        promise: () => Promise.resolve({ Stacks: [ stackInfo] })
+        promise: () => Promise.resolve({ Stacks: [stackInfo] })
     });
 
     try {
@@ -123,7 +123,7 @@ test('[lookup.info] success', async (t) => {
     t.end();
 });
 
-test.test('[lookup.info] with resources', async (t) => {
+test.test('[lookup.info] with resources', async(t) => {
     AWS.stub('CloudFormation', 'describeStacks').returns({
         promise: () => Promise.resolve({ Stacks: [{}] })
     });
@@ -152,7 +152,7 @@ test.test('[lookup.info] with resources', async (t) => {
     t.end();
 });
 
-test.test('[lookup.info] resource lookup failure', async (t) => {
+test.test('[lookup.info] resource lookup failure', async(t) => {
     AWS.stub('CloudFormation', 'describeStacks').returns({
         promise: () => Promise.resolve({ Stacks: [{}] })
     });
@@ -176,7 +176,7 @@ test.test('[lookup.info] resource lookup failure', async (t) => {
     t.end();
 });
 
-test('[lookup.parameters] lookup.info error', async (t) => {
+test('[lookup.parameters] lookup.info error', async(t) => {
     AWS.stub('CloudFormation', 'describeStacks').returns({
         promise: () => Promise.resolve({ Stacks: [] })
     });
@@ -192,7 +192,7 @@ test('[lookup.parameters] lookup.info error', async (t) => {
     t.end();
 });
 
-test('[lookup.info] secure', async (t) => {
+test('[lookup.info] secure', async(t) => {
     const date = new Date();
 
     const stackInfo = {
@@ -244,9 +244,9 @@ test('[lookup.info] secure', async (t) => {
         const encrypted = new Buffer.from(params.CiphertextBlob, 'base64').toString('utf8');
 
         if (encrypted === 'EncryptedValue1') {
-            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }))
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }));
         } else if (encrypted === 'EncryptedValue2') {
-            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }))
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }));
         }
         t.fail('Unrecognized encrypted value ' + encrypted);
     });
@@ -263,7 +263,7 @@ test('[lookup.info] secure', async (t) => {
     t.end();
 });
 
-test('[lookup.info] secure error', async (t) => {
+test('[lookup.info] secure error', async(t) => {
     const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
@@ -302,7 +302,7 @@ test('[lookup.info] secure error', async (t) => {
     t.end();
 });
 
-test('[lookup.parameters] success', async (t) => {
+test('[lookup.parameters] success', async(t) => {
     const stackInfo = {
         StackId: 'stack-id',
         StackName: 'my-stack',
@@ -357,7 +357,7 @@ test('[lookup.parameters] success', async (t) => {
     t.end();
 });
 
-test('[lookup.template] getTemplate error', async (t) => {
+test('[lookup.template] getTemplate error', async(t) => {
     AWS.stub('CloudFormation', 'getTemplate').yields(new Error('cloudformation failed'));
 
     try {
@@ -371,8 +371,8 @@ test('[lookup.template] getTemplate error', async (t) => {
     t.end();
 });
 
-test('[lookup.template] stack does not exist', async (t) => {
-    AWS.stub('CloudFormation', 'getTemplate', (params) => {
+test('[lookup.template] stack does not exist', async(t) => {
+    AWS.stub('CloudFormation', 'getTemplate', () => {
         const err = new Error('Stack with id my-stack does not exist');
         err.code = 'ValidationError';
         throw err;
@@ -389,8 +389,8 @@ test('[lookup.template] stack does not exist', async (t) => {
     t.end();
 });
 
-test('[lookup.template] success', async (t) => {
-    AWS.stub('CloudFormation', 'getTemplate', function (params) {
+test('[lookup.template] success', async(t) => {
+    AWS.stub('CloudFormation', 'getTemplate', function(params) {
         t.deepEqual(params, {
             StackName: 'my-stack',
             TemplateStage: 'Original'
@@ -413,7 +413,7 @@ test('[lookup.template] success', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] bucket location error', async (t) => {
+test('[lookup.configurations] bucket location error', async(t) => {
     AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
     try {
@@ -427,12 +427,12 @@ test('[lookup.configurations] bucket location error', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] bucket does not exist', async (t) => {
+test('[lookup.configurations] bucket does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'listObjects', (params) => {
+    AWS.stub('S3', 'listObjects', () => {
         const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
         throw err;
@@ -449,7 +449,7 @@ test('[lookup.configurations] bucket does not exist', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] S3 error', async (t) => {
+test('[lookup.configurations] S3 error', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -470,7 +470,7 @@ test('[lookup.configurations] S3 error', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] no saved configs found', async (t) => {
+test('[lookup.configurations] no saved configs found', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -490,7 +490,7 @@ test('[lookup.configurations] no saved configs found', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] found multiple saved configs', async (t) => {
+test('[lookup.configurations] found multiple saved configs', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -520,7 +520,7 @@ test('[lookup.configurations] found multiple saved configs', async (t) => {
     t.end();
 });
 
-test('[lookup.configurations] region specified', async (t) => {
+test('[lookup.configurations] region specified', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -544,7 +544,7 @@ test('[lookup.configurations] region specified', async (t) => {
     t.end();
 });
 
-test('[lookup.configuration] bucket location error', async (t) => {
+test('[lookup.configuration] bucket location error', async(t) => {
     AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
     try {
@@ -558,12 +558,12 @@ test('[lookup.configuration] bucket location error', async (t) => {
     t.end();
 });
 
-test('[lookup.configuration] bucket does not exist', async (t) => {
+test('[lookup.configuration] bucket does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', (params) => {
+    AWS.stub('S3', 'getObject', () => {
         const err = new Error('The specified bucket does not exist');
         err.code = 'NoSuchBucket';
         throw err;
@@ -580,7 +580,7 @@ test('[lookup.configuration] bucket does not exist', async (t) => {
     t.end();
 });
 
-test('[lookup.configuration] S3 error', async (t) => {
+test('[lookup.configuration] S3 error', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -601,12 +601,12 @@ test('[lookup.configuration] S3 error', async (t) => {
     t.end();
 });
 
-test('[lookup.configuration] requested configuration does not exist', async (t) => {
+test('[lookup.configuration] requested configuration does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', (params) => {
+    AWS.stub('S3', 'getObject', () => {
         const err = new Error('The specified key does not exist.');
         err.code = 'NoSuchKey';
         throw err;
@@ -623,7 +623,7 @@ test('[lookup.configuration] requested configuration does not exist', async (t) 
     t.end();
 });
 
-test('[lookup.configuration] cannot parse object data', async (t) => {
+test('[lookup.configuration] cannot parse object data', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -643,7 +643,7 @@ test('[lookup.configuration] cannot parse object data', async (t) => {
     t.end();
 });
 
-test('[lookup.configuration] success', async (t) => {
+test('[lookup.configuration] success', async(t) => {
     const info = {
         Name: 'Chuck',
         Age: 18,
@@ -677,7 +677,7 @@ test('[lookup.configuration] success', async (t) => {
     t.end();
 });
 
-test('[lookup.defaultConfiguration] bucket location error', async (t) => {
+test('[lookup.defaultConfiguration] bucket location error', async(t) => {
     AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
     try {
@@ -691,12 +691,12 @@ test('[lookup.defaultConfiguration] bucket location error', async (t) => {
     t.end();
 });
 
-test('[lookup.defaultConfiguration] requested configuration does not exist', async (t) => {
+test('[lookup.defaultConfiguration] requested configuration does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
 
-    AWS.stub('S3', 'getObject', (params) =>  {
+    AWS.stub('S3', 'getObject', () =>  {
         const err = new Error('The specified key does not exist.');
         err.code = 'NoSuchKey';
         throw err;
@@ -706,14 +706,14 @@ test('[lookup.defaultConfiguration] requested configuration does not exist', asy
         const info = await Lookup.defaultConfiguration('s3://my-bucket/my-config.cfn.json');
         t.deepEqual(info, {}, 'provided blank info');
     } catch (err) {
-        t.error(err)
+        t.error(err);
     }
 
     AWS.S3.restore();
     t.end();
 });
 
-test('[lookup.defaultConfiguration] cannot parse object data', async (t) => {
+test('[lookup.defaultConfiguration] cannot parse object data', async(t) => {
     AWS.stub('S3', 'getBucketLocation').returns({
         promise: () => Promise.resolve('us-east-1')
     });
@@ -733,7 +733,7 @@ test('[lookup.defaultConfiguration] cannot parse object data', async (t) => {
     t.end();
 });
 
-test('[lookup.defaultConfiguration] success', async (t) => {
+test('[lookup.defaultConfiguration] success', async(t) => {
     const info = {
         Name: 'Chuck',
         Age: 18,
@@ -767,8 +767,8 @@ test('[lookup.defaultConfiguration] success', async (t) => {
     t.end();
 });
 
-test('[lookup.bucketRegion] no bucket', async (t) => {
-    AWS.stub('S3', 'getBucketLocation', (params) => {
+test('[lookup.bucketRegion] no bucket', async(t) => {
+    AWS.stub('S3', 'getBucketLocation', () => {
         const err = new Error('failure');
         err.code = 'NoSuchBucket';
         throw err;
@@ -785,7 +785,7 @@ test('[lookup.bucketRegion] no bucket', async (t) => {
     t.end();
 });
 
-test('[lookup.bucketRegion] failure', async (t) => {
+test('[lookup.bucketRegion] failure', async(t) => {
     AWS.stub('S3', 'getBucketLocation').yields(new Error('failure'));
 
     try {
@@ -799,8 +799,8 @@ test('[lookup.bucketRegion] failure', async (t) => {
     t.end();
 });
 
-test('[lookup.bucketRegion] no bucket', async (t) => {
-    AWS.stub('S3', 'getBucketLocation', (params) => {
+test('[lookup.bucketRegion] no bucket', async(t) => {
+    AWS.stub('S3', 'getBucketLocation', () => {
         const err = new Error('failure');
         err.code = 'NoSuchBucket';
         throw err;
@@ -817,8 +817,8 @@ test('[lookup.bucketRegion] no bucket', async (t) => {
     t.end();
 });
 
-test('[lookup.bucketRegion] region specified', async (t) => {
-    AWS.stub('S3', 'getBucketLocation', (params) => {
+test('[lookup.bucketRegion] region specified', async(t) => {
+    AWS.stub('S3', 'getBucketLocation', () => {
         const err = new Error('failure');
         err.code = 'NoSuchBucket';
         throw err;
@@ -839,7 +839,7 @@ test('[lookup.bucketRegion] region specified', async (t) => {
     t.end();
 });
 
-test('[lookup.decryptParameters] failure', async (t) => {
+test('[lookup.decryptParameters] failure', async(t) => {
     AWS.stub('KMS', 'decrypt',).yields(new Error('failure'));
 
     try {
@@ -855,13 +855,13 @@ test('[lookup.decryptParameters] failure', async (t) => {
     t.end();
 });
 
-test('[lookup.decryptParameters] success', async (t) => {
+test('[lookup.decryptParameters] success', async(t) => {
     AWS.stub('KMS', 'decrypt', function(params) {
         const encrypted = new Buffer.from(params.CiphertextBlob, 'base64').toString('utf8');
         if (encrypted === 'EncryptedValue1') {
-            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }))
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue1')).toString('base64') }));
         } else if (encrypted === 'EncryptedValue2') {
-            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }))
+            return this.request.promise.returns(Promise.resolve({ Plaintext: (new Buffer.from('DecryptedValue2')).toString('base64') }));
         }
 
         t.fail('Unrecognized encrypted value ' + encrypted);

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -10,7 +10,7 @@ const expected = require('./fixtures/template.json');
 process.env.AWS_ACCESS_KEY_ID = '-';
 process.env.AWS_SECRET_ACCESS_KEY = '-';
 
-test('[template.read] local file does not exist', async (t) => {
+test('[template.read] local file does not exist', async(t) => {
     try {
         await Template.read('./fake');
         t.fail();
@@ -21,7 +21,7 @@ test('[template.read] local file does not exist', async (t) => {
     t.end();
 });
 
-test('[template.read] local file cannot be parsed', async (t) => {
+test('[template.read] local file cannot be parsed', async(t) => {
     try {
         await Template.read(path.resolve(__dirname, 'fixtures', 'malformed-template.json'));
         t.fail();
@@ -33,7 +33,7 @@ test('[template.read] local file cannot be parsed', async (t) => {
     t.end();
 });
 
-test('[template.read] local js file cannot be parsed', async (t) => {
+test('[template.read] local js file cannot be parsed', async(t) => {
     try {
         await Template.read(path.resolve(__dirname, 'fixtures', 'malformed-template.js'));
         t.fail();
@@ -45,7 +45,7 @@ test('[template.read] local js file cannot be parsed', async (t) => {
     t.end();
 });
 
-test('[template.read] S3 no access', async (t) => {
+test('[template.read] S3 no access', async(t) => {
     try {
         await Template.read('s3://mapbox/fake');
         t.fail();
@@ -56,7 +56,7 @@ test('[template.read] S3 no access', async (t) => {
     t.end();
 });
 
-test('[template.read] S3 bucket does not exist', async (t) => {
+test('[template.read] S3 bucket does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation', (params) => {
         t.deepEqual(params, { Bucket: 'my' }, 'requested bucket location');
         const error = new Error('Bucket does not exist');
@@ -75,7 +75,7 @@ test('[template.read] S3 bucket does not exist', async (t) => {
     t.end();
 });
 
-test('[template.read] S3 file does not exist', async (t) => {
+test('[template.read] S3 file does not exist', async(t) => {
     AWS.stub('S3', 'getObject', (params) => {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         const error = new Error('Object does not exist');
@@ -99,7 +99,7 @@ test('[template.read] S3 file does not exist', async (t) => {
     t.end();
 });
 
-test('[template.read] S3 file cannot be parsed', async (t) => {
+test('[template.read] S3 file cannot be parsed', async(t) => {
     AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         const malformed = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'malformed-template.json'));
@@ -122,18 +122,18 @@ test('[template.read] S3 file cannot be parsed', async (t) => {
     t.end();
 });
 
-test('[template.read] local JSON', async (t) => {
+test('[template.read] local JSON', async(t) => {
     try {
         const found = await Template.read(path.resolve(__dirname, 'fixtures', 'template.json'));
         t.deepEqual(found, expected, 'got template JSON');
     } catch (err) {
-        t.error(err)
+        t.error(err);
     }
 
     t.end();
 });
 
-test('[template.read] local sync JS', async (t) => {
+test('[template.read] local sync JS', async(t) => {
     try {
         const found = await Template.read(path.resolve(__dirname, 'fixtures', 'template-sync.js'));
         t.deepEqual(found, expected, 'got template JSON');
@@ -144,7 +144,7 @@ test('[template.read] local sync JS', async (t) => {
     t.end();
 });
 
-test('[template.read] local sync JS (relative path)', async (t) => {
+test('[template.read] local sync JS (relative path)', async(t) => {
     const relativePath = path.resolve(__dirname, 'fixtures', 'template-sync.js').replace(process.cwd(), '').substr(1);
     t.equal(relativePath[0] !== '/', true, 'relative path: ' + relativePath);
 
@@ -158,7 +158,7 @@ test('[template.read] local sync JS (relative path)', async (t) => {
     t.end();
 });
 
-test('[template.read] local async JS with options', async (t) => {
+test('[template.read] local async JS with options', async(t) => {
     try {
         const found = await Template.read(path.resolve(__dirname, 'fixtures', 'template-async.js'), { some: 'options' });
         t.deepEqual(found, { some: 'options' }, 'got template JSON');
@@ -169,7 +169,7 @@ test('[template.read] local async JS with options', async (t) => {
     t.end();
 });
 
-test('[template.read] local async JS without options', async (t) => {
+test('[template.read] local async JS without options', async(t) => {
     try {
         const found = await Template.read(path.resolve(__dirname, 'fixtures', 'template-async.js'));
         t.deepEqual(found, {}, 'got template JSON');
@@ -180,7 +180,7 @@ test('[template.read] local async JS without options', async (t) => {
     t.end();
 });
 
-test('[template.read] S3 JSON', async (t) => {
+test('[template.read] S3 JSON', async(t) => {
     AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         return this.request.promise.returns(Promise.resolve({ Body: new Buffer(JSON.stringify(expected)) }));

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -57,8 +57,6 @@ test('[template.read] S3 no access', async (t) => {
 });
 
 test('[template.read] S3 bucket does not exist', async (t) => {
-    t.plan(2);
-
     AWS.stub('S3', 'getBucketLocation', (params) => {
         t.deepEqual(params, { Bucket: 'my' }, 'requested bucket location');
         const error = new Error('Bucket does not exist');
@@ -78,8 +76,6 @@ test('[template.read] S3 bucket does not exist', async (t) => {
 });
 
 test('[template.read] S3 file does not exist', async (t) => {
-    t.plan(3);
-
     AWS.stub('S3', 'getObject', (params) => {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         const error = new Error('Object does not exist');
@@ -104,8 +100,6 @@ test('[template.read] S3 file does not exist', async (t) => {
 });
 
 test('[template.read] S3 file cannot be parsed', async (t) => {
-    t.plan(3);
-
     AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         const malformed = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'malformed-template.json'));
@@ -187,8 +181,6 @@ test('[template.read] local async JS without options', async (t) => {
 });
 
 test('[template.read] S3 JSON', async (t) => {
-    t.plan(4);
-
     AWS.stub('S3', 'getObject', function(params) {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
         return this.request.promise.returns(Promise.resolve({ Body: new Buffer(JSON.stringify(expected)) }));
@@ -211,14 +203,14 @@ test('[template.read] S3 JSON', async (t) => {
 });
 
 test('[template.questions] provides expected questions without encryption', (t) => {
-    const questions = template.questions(expected);
+    const questions = Template.questions(expected);
 
     t.equal(questions.length, 6, 'all questions provided');
 
     const q = queue(1);
 
     q.defer(function(next) {
-        var name = questions[0];
+        const name = questions[0];
         t.equal(name.type, 'input', 'correct type for Name');
         t.equal(name.name, 'Name', 'correct name for Name');
         t.equal(name.message, 'Name. Someone\'s first name:', 'correct message for Name');
@@ -229,7 +221,7 @@ test('[template.questions] provides expected questions without encryption', (t) 
     });
 
     q.defer(function(next) {
-        var age = questions[1];
+        const age = questions[1];
         t.equal(age.type, 'input', 'correct type for Age');
         t.equal(age.name, 'Age', 'correct name for Age');
         t.equal(age.message, 'Age:', 'correct message for Age');
@@ -241,7 +233,7 @@ test('[template.questions] provides expected questions without encryption', (t) 
     });
 
     q.defer(function(next) {
-        var handedness = questions[2];
+        const handedness = questions[2];
         t.equal(handedness.type, 'list', 'correct type for Handedness');
         t.equal(handedness.name, 'Handedness', 'correct name for Handedness');
         t.equal(handedness.message, 'Handedness. Their dominant hand:', 'correct message for Handedness');
@@ -251,7 +243,7 @@ test('[template.questions] provides expected questions without encryption', (t) 
     });
 
     q.defer(function(next) {
-        var pets = questions[3];
+        const pets = questions[3];
         t.equal(pets.type, 'input', 'correct type for Pets');
         t.equal(pets.name, 'Pets', 'correct name for Pets');
         t.equal(pets.message, 'Pets. The names of their pets:', 'correct message for Pets');
@@ -259,7 +251,7 @@ test('[template.questions] provides expected questions without encryption', (t) 
     });
 
     q.defer(function(next) {
-        var numbers = questions[4];
+        const numbers = questions[4];
         t.equal(numbers.type, 'input', 'correct type for LuckyNumbers');
         t.equal(numbers.name, 'LuckyNumbers', 'correct name for LuckyNumbers');
         t.equal(numbers.message, 'LuckyNumbers. Their lucky numbers:', 'correct message for LuckyNumbers');
@@ -269,7 +261,7 @@ test('[template.questions] provides expected questions without encryption', (t) 
     });
 
     q.defer(function(next) {
-        var password = questions[5];
+        const password = questions[5];
         t.equal(password.type, 'password', 'correct type for SecretPassword');
         t.equal(password.name, 'SecretPassword', 'correct name for SecretPassword');
         t.equal(password.message, 'SecretPassword. [secure] Their secret password:', 'correct message for SecretPassword');
@@ -297,19 +289,19 @@ test('[template.questions] respects overrides', (t) => {
         return callback(null, { CiphertextBlob: new Buffer(params.Plaintext) });
     });
 
-    var overrides = {
+    const overrides = {
         defaults: { Name: 'Chuck' },
         messages: { Name: 'Somebody' },
         choices: { Handedness: ['top', 'bottom'] },
         kmsKeyId: 'this is a bomb key'
     };
 
-    var questions = template.questions(expected, overrides);
+    const questions = Template.questions(expected, overrides);
 
-    var q = queue(1);
+    const q = queue(1);
 
     q.defer(function(next) {
-        var name = questions[0];
+        const name = questions[0];
         t.equal(name.default, 'Chuck', 'overriden default for Name');
         t.equal(name.message, 'Somebody', 'overriden message for Name');
         name.async = function() {
@@ -323,14 +315,14 @@ test('[template.questions] respects overrides', (t) => {
     });
 
     q.defer(function(next) {
-        var handedness = questions[2];
+        const handedness = questions[2];
         t.deepEqual(handedness.choices, ['top', 'bottom'], 'overriden choices for Handedness');
         next();
     });
 
 
     q.defer(function(next) {
-        var password = questions[5];
+        const password = questions[5];
         password.async = function() {
             return function(err, encrypted) {
                 t.ifError(err, 'encryption doesn\'t cause errors');
@@ -343,7 +335,7 @@ test('[template.questions] respects overrides', (t) => {
     });
 
     q.defer(function(next) {
-        var password = questions[5];
+        const password = questions[5];
         password.async = function() {
             return function(err, encrypted) {
                 t.ifError(err, 'encryption doesn\'t cause errors');
@@ -367,9 +359,9 @@ test('[template.questions] defaults kms key to correct default', (t) => {
         return callback(null, { CiphertextBlob: new Buffer(params.Plaintext) });
     });
 
-    var questions = template.questions(expected, { kmsKeyId: true });
+    const questions = Template.questions(expected, { kmsKeyId: true });
 
-    var password = questions[5];
+    const password = questions[5];
     password.async = function() {
         return function(err, encrypted) {
             t.ifError(err, 'encryption doesn\'t cause errors');
@@ -383,13 +375,13 @@ test('[template.questions] defaults kms key to correct default', (t) => {
 });
 
 test('[template.questions] no parameters', (t) => {
-    var questions = template.questions({});
+    const questions = Template.questions({});
     t.deepEqual(questions, [], 'no further questions');
     t.end();
 });
 
 test('[template.questions] no description = no encryption', (t) => {
-    var questions = template.questions({ Parameters: { Undefined: {} } }, { kmsKeyId: 'my-key' });
+    const questions = Template.questions({ Parameters: { Undefined: {} } }, { kmsKeyId: 'my-key' });
     questions[0].async = function() {
         return function(err, input) {
             t.ifError(err, 'success');
@@ -402,17 +394,17 @@ test('[template.questions] no description = no encryption', (t) => {
 
 test('[template.questions] handles failure during kms encryption', (t) => {
     AWS.stub('KMS', 'encrypt', function(params, callback) {
-        var err = new Error('Bad encryption error');
+        const err = new Error('Bad encryption error');
         err.code = 'Whoops';
         return callback(err);
     });
 
-    var questions = template.questions(expected, { kmsKeyId: true });
+    const questions = Template.questions(expected, { kmsKeyId: true });
 
-    var password = questions[5];
+    const password = questions[5];
     password.async = function() {
         return function(err, encrypted) {
-            t.ok(err instanceof template.KmsError, 'expected error type');
+            t.ok(err instanceof Template.KmsError, 'expected error type');
             t.equal(err.toString(), 'KmsError: Whoops: Bad encryption error', 'correct error');
             t.equal(encrypted, undefined, 'no encrypted return value');
             AWS.KMS.restore();
@@ -424,17 +416,17 @@ test('[template.questions] handles failure during kms encryption', (t) => {
 
 test('[template.questions] handles kms key lookup failure during kms encryption with special message', (t) => {
     AWS.stub('KMS', 'encrypt', function(params, callback) {
-        var error = new Error('Invalid key');
+        const error = new Error('Invalid key');
         error.code = 'NotFoundException';
         return callback(error);
     });
 
-    var questions = template.questions(expected, { kmsKeyId: 'garbage' });
+    const questions = Template.questions(expected, { kmsKeyId: 'garbage' });
 
-    var password = questions[5];
+    const password = questions[5];
     password.async = function() {
         return function(err, encrypted) {
-            t.ok(err instanceof template.NotFoundError, 'expected error type');
+            t.ok(err instanceof Template.NotFoundError, 'expected error type');
             t.equal(err.toString(), 'NotFoundError: Unable to find KMS encryption key "garbage"', 'correct error');
             t.equal(encrypted, undefined, 'no encrypted return value');
             AWS.KMS.restore();
@@ -445,10 +437,10 @@ test('[template.questions] handles kms key lookup failure during kms encryption 
 });
 
 test('[template.questions] reject defaults that are not in a list of allowed values', (t) => {
-    var parameters = { List: { Type: 'String', AllowedValues: ['one', 'two'] } };
-    var overrides = { defaults: { List: 'three' } };
+    const parameters = { List: { Type: 'String', AllowedValues: ['one', 'two'] } };
+    const overrides = { defaults: { List: 'three' } };
 
-    var questions = template.questions({ Parameters: parameters }, overrides);
+    const questions = Template.questions({ Parameters: parameters }, overrides);
     t.notEqual(questions[0].default, 'three', 'rejected disallowed default value');
     t.end();
 });

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -59,8 +59,8 @@ test('[template.read] S3 no access', async(t) => {
 test('[template.read] S3 bucket does not exist', async(t) => {
     AWS.stub('S3', 'getBucketLocation', (params) => {
         t.deepEqual(params, { Bucket: 'my' }, 'requested bucket location');
-        const error = new Error('Bucket does not exist');
-        error.code = 'NotFoundError';
+        const err = new Error('Bucket does not exist');
+        err.code = 'NotFoundError';
         throw err;
     });
 
@@ -78,8 +78,8 @@ test('[template.read] S3 bucket does not exist', async(t) => {
 test('[template.read] S3 file does not exist', async(t) => {
     AWS.stub('S3', 'getObject', (params) => {
         t.deepEqual(params, { Bucket: 'my', Key: 'template' }, 'requested correct S3 object');
-        const error = new Error('Object does not exist');
-        error.code = 'NotFoundError';
+        const err = new Error('Object does not exist');
+        err.code = 'NotFoundError';
         throw err;
     });
 


### PR DESCRIPTION
### Context

Now that ES6 syntax is fully supported, migrate all callback style APIs to the more modern and straightforward `Promise` API.

