### PR TITLE
Request Processed Template if Original Failsl to Parse

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -113,18 +113,37 @@ export default class Lookup {
     static async template(name, region) {
         const cfn = new AWS.CloudFormation({ region });
 
+        let data;
         try {
-            const data = await cfn.getTemplate({
+            data = await cfn.getTemplate({
                 StackName: name,
-                TemplateStage: 'Original'
+                TemplateStage: 'Original' // This can potentially return a YAML file if the stack was created by a different deploy tool
             }).promise();
-
-            return JSON.parse(data.TemplateBody);
         } catch (err) {
             if (err.code === 'ValidationError' && /Stack with id/.test(err.message)) {
                 throw new Lookup.StackNotFoundError('Stack %s not found in %s', name, region);
             } else {
                 throw new Lookup.CloudFormationError('%s: %s', err.code, err.message);
+            }
+        }
+
+        try {
+            // If this fails the above API probably returned YAML, ask for the processed result
+            return JSON.parse(data.TemplateBody);
+        } catch (err) {
+            try {
+                data = await cfn.getTemplate({
+                    StackName: name,
+                    TemplateStage: 'Processed'
+                }).promise();
+
+                return JSON.parse(data.TemplateBody);
+            } catch (err) {
+                if (err.code === 'ValidationError' && /Stack with id/.test(err.message)) {
+                    throw new Lookup.StackNotFoundError('Stack %s not found in %s', name, region);
+                } else {
+                    throw new Lookup.CloudFormationError('%s: %s', err.code, err.message);
+                }
             }
         }
     }


### PR DESCRIPTION
### Context

The `cf.getTemplate` endpoint can return either JSON or YAML depending on what was originally uploaded to create the stack.
Deploy itself will always upload a JSON CF template.

If converting a stack from another deploy tool to `deploy`, fallback to requesting the processed JSON in order to not fail during parameter lookup.